### PR TITLE
feat: add _skills/ with non-monolith skills layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ Documentation = "https://scitex-app.readthedocs.io/"
 [tool.hatch.build.targets.wheel]
 packages = ["src/scitex_app"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/scitex_app/_skills" = "scitex_app/_skills"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/scitex_app/_skills/scitex-app/SKILL.md
+++ b/src/scitex_app/_skills/scitex-app/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: scitex-app
+description: App developer SDK — scaffold, validate, dev-install, standalone shell, file operations, and cloud SDK for building SciTeX workspace apps. Use when creating, testing, or deploying SciTeX apps.
+allowed-tools: mcp__scitex__app_*
+---
+
+# scitex-app — App Developer SDK
+
+Toolkit for building SciTeX workspace apps with scaffold, validation, standalone mode, and cloud integration.
+
+## Quick Start
+
+```bash
+# Scaffold a new app
+scitex-app app init . --name my_app
+
+# Validate structure
+scitex-app app validate .
+
+# Dev-install on SciTeX Cloud
+scitex-app app dev-install . --server http://127.0.0.1:8000
+
+# Launch standalone with workspace shell
+my-app gui
+```
+
+```python
+from scitex_app import build_tree
+from scitex_app.sdk import get_files
+from scitex_app._standalone import run_standalone
+
+# File operations via SDK
+files = get_files("./my_project")
+content = files.read("config/settings.yaml")
+files.write("output/result.csv", csv_text)
+tree_data = files.list("", extensions=[".yaml"])
+
+# Build file tree for UI
+tree = build_tree(files, max_depth=2)
+
+# Launch standalone app
+run_standalone(app_module="my_app", port=8050, open_browser=True)
+```
+
+## Python API
+
+### Core
+
+| Function | Purpose |
+|----------|---------|
+| `build_tree(files, max_depth)` | Build nested file tree dict for UI |
+| `run_standalone(app_module, port, host, ...)` | Launch standalone Django server with shell |
+
+### scitex_app.paths — Path Resolution
+
+| Function | Purpose |
+|----------|---------|
+| `get_base_dir(base_dir=None)` | Get base directory for apps |
+| `resolve_user_project_dir(owner, repo)` | Resolve user project directory |
+| `resolve_published_project_dir(slug)` | Resolve published app directory |
+| `resolve_manifest(project_dir)` | Find manifest.json in project |
+| `resolve_template_dir(project_dir)` | Get template directory |
+| `resolve_static_dir(project_dir)` | Get static files directory |
+| `validate_project_structure(project_dir)` | Validate app directory structure |
+
+### scitex_app.validator — App Validation
+
+| Class/Function | Purpose |
+|----------------|---------|
+| `AppValidator` | Validate manifest, security, structure, bundle size |
+| `ValidationResult` | Dataclass with validation results |
+
+### scitex_app.sdk — Cloud SDK
+
+| Function | Purpose |
+|----------|---------|
+| `get_client()` | Get platform API client |
+| `reset_client()` | Reset client instance |
+| `CloudFilesBackend` | Cloud-backed file operations |
+| `sdk.data` | Cloud data CRUD operations |
+| `sdk.files` | Cloud file upload/download |
+| `sdk.jobs` | Cloud job submission/status |
+
+## App Lifecycle CLI
+
+| Command | Purpose |
+|---------|---------|
+| `scitex-app app init . [--frontend react]` | Scaffold app (17-23 files) |
+| `scitex-app app validate .` | Check structure, security, manifest |
+| `scitex-app app dev-install .` | Install on SciTeX Cloud server |
+| `scitex-app app submit .` | Submit for public review |
+
+## File Operations CLI
+
+```bash
+scitex-app read <path> [--binary] [--json]
+scitex-app write <path> [--stdin] [--json] [--dry-run]
+scitex-app list [<dir>] [--ext <ext>] [--json]
+scitex-app exists <path> [--json]
+scitex-app delete <path> [--dry-run] [--json]
+scitex-app rename <old> <new> [--dry-run] [--json]
+scitex-app copy <src> <dest> [--dry-run] [--json]
+```
+
+## Other CLI Commands
+
+```bash
+# Documentation
+scitex-app docs --page quickstart
+scitex-app docs --list
+
+# MCP server
+scitex-app mcp start
+scitex-app mcp list-tools [-v]
+scitex-app mcp doctor
+scitex-app mcp installation
+
+# Introspection
+scitex-app list-python-apis [-v] [--json]
+```
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SCITEX_BASE_DIR` | Base directory for app path resolution |
+| `SCITEX_API_TOKEN` | JWT token for cloud API authentication |
+| `SCITEX_API_URL` | Cloud API base URL (default: http://127.0.0.1:8000) |
+| `SCITEX_SERVER_URL` | Server URL for app commands |
+| `SCITEX_WORKING_DIR` | Working directory for standalone mode |
+| `SCITEX_UI_STATIC` | Path to scitex-ui static files |
+| `DJANGO_SECRET_KEY` | Django secret for standalone mode |
+| `DJANGO_DEBUG` | Django debug mode (default: true) |
+| `ANTHROPIC_API_KEY` | API key for chat backend |
+| `LLM_MODEL` | LLM model for chat (default: claude-sonnet-4-20250514) |
+
+## MCP Tools (for AI agents)
+
+| Tool | Parameters | Purpose |
+|------|-----------|---------|
+| `app_scaffold` | `name`, `frontend` | Scaffold new app |
+| `app_validate` | `path` | Validate app structure |
+| `app_read_file` | `path`, `root`, `binary` | Read file content |
+| `app_write_file` | `path`, `content`, `root` | Write file |
+| `app_list_files` | `directory`, `root`, `extensions` | List directory |
+| `app_file_exists` | `path`, `root` | Check file existence |
+| `app_delete_file` | `path`, `root` | Delete file |
+| `app_copy_file` | `src_path`, `dest_path`, `root` | Copy file |
+| `app_rename_file` | `old_path`, `new_path`, `root` | Rename/move file |

--- a/src/scitex_app/_skills/scitex-app/SKILL.md
+++ b/src/scitex_app/_skills/scitex-app/SKILL.md
@@ -8,133 +8,35 @@ allowed-tools: mcp__scitex__app_*
 
 Toolkit for building SciTeX workspace apps with scaffold, validation, standalone mode, and cloud integration.
 
+## Sub-skills
+
+* [files-sdk](files-sdk.md) — `get_files()`, `FilesBackend` protocol, `FileSystemBackend`, `build_tree()`
+* [app-lifecycle](app-lifecycle.md) — `init_app()`, `validate()`, `AppValidator`, `ValidationResult`
+* [paths](paths.md) — Path resolution: `get_base_dir()`, `resolve_*`, `parse_dev_module_name()`
+* [standalone](standalone.md) — `run_standalone()` for local Django workspace shell
+* [cli](cli.md) — `scitex-app` CLI: file commands, app commands, MCP, introspection
+* [environment-vars](environment-vars.md) — All environment variable configuration
+
 ## Quick Start
 
 ```bash
-# Scaffold a new app
 scitex-app app init . --name my_app
-
-# Validate structure
 scitex-app app validate .
-
-# Dev-install on SciTeX Cloud
 scitex-app app dev-install . --server http://127.0.0.1:8000
-
-# Launch standalone with workspace shell
-my-app gui
 ```
 
 ```python
-from scitex_app import build_tree
-from scitex_app.sdk import get_files
+from scitex_app.sdk import get_files, build_tree
 from scitex_app._standalone import run_standalone
 
-# File operations via SDK
 files = get_files("./my_project")
 content = files.read("config/settings.yaml")
 files.write("output/result.csv", csv_text)
-tree_data = files.list("", extensions=[".yaml"])
-
-# Build file tree for UI
 tree = build_tree(files, max_depth=2)
-
-# Launch standalone app
-run_standalone(app_module="my_app", port=8050, open_browser=True)
+run_standalone(app_module="my_app", port=8050)
 ```
 
-## Python API
-
-### Core
-
-| Function | Purpose |
-|----------|---------|
-| `build_tree(files, max_depth)` | Build nested file tree dict for UI |
-| `run_standalone(app_module, port, host, ...)` | Launch standalone Django server with shell |
-
-### scitex_app.paths — Path Resolution
-
-| Function | Purpose |
-|----------|---------|
-| `get_base_dir(base_dir=None)` | Get base directory for apps |
-| `resolve_user_project_dir(owner, repo)` | Resolve user project directory |
-| `resolve_published_project_dir(slug)` | Resolve published app directory |
-| `resolve_manifest(project_dir)` | Find manifest.json in project |
-| `resolve_template_dir(project_dir)` | Get template directory |
-| `resolve_static_dir(project_dir)` | Get static files directory |
-| `validate_project_structure(project_dir)` | Validate app directory structure |
-
-### scitex_app.validator — App Validation
-
-| Class/Function | Purpose |
-|----------------|---------|
-| `AppValidator` | Validate manifest, security, structure, bundle size |
-| `ValidationResult` | Dataclass with validation results |
-
-### scitex_app.sdk — Cloud SDK
-
-| Function | Purpose |
-|----------|---------|
-| `get_client()` | Get platform API client |
-| `reset_client()` | Reset client instance |
-| `CloudFilesBackend` | Cloud-backed file operations |
-| `sdk.data` | Cloud data CRUD operations |
-| `sdk.files` | Cloud file upload/download |
-| `sdk.jobs` | Cloud job submission/status |
-
-## App Lifecycle CLI
-
-| Command | Purpose |
-|---------|---------|
-| `scitex-app app init . [--frontend react]` | Scaffold app (17-23 files) |
-| `scitex-app app validate .` | Check structure, security, manifest |
-| `scitex-app app dev-install .` | Install on SciTeX Cloud server |
-| `scitex-app app submit .` | Submit for public review |
-
-## File Operations CLI
-
-```bash
-scitex-app read <path> [--binary] [--json]
-scitex-app write <path> [--stdin] [--json] [--dry-run]
-scitex-app list [<dir>] [--ext <ext>] [--json]
-scitex-app exists <path> [--json]
-scitex-app delete <path> [--dry-run] [--json]
-scitex-app rename <old> <new> [--dry-run] [--json]
-scitex-app copy <src> <dest> [--dry-run] [--json]
-```
-
-## Other CLI Commands
-
-```bash
-# Documentation
-scitex-app docs --page quickstart
-scitex-app docs --list
-
-# MCP server
-scitex-app mcp start
-scitex-app mcp list-tools [-v]
-scitex-app mcp doctor
-scitex-app mcp installation
-
-# Introspection
-scitex-app list-python-apis [-v] [--json]
-```
-
-## Environment Variables
-
-| Variable | Purpose |
-|----------|---------|
-| `SCITEX_BASE_DIR` | Base directory for app path resolution |
-| `SCITEX_API_TOKEN` | JWT token for cloud API authentication |
-| `SCITEX_API_URL` | Cloud API base URL (default: http://127.0.0.1:8000) |
-| `SCITEX_SERVER_URL` | Server URL for app commands |
-| `SCITEX_WORKING_DIR` | Working directory for standalone mode |
-| `SCITEX_UI_STATIC` | Path to scitex-ui static files |
-| `DJANGO_SECRET_KEY` | Django secret for standalone mode |
-| `DJANGO_DEBUG` | Django debug mode (default: true) |
-| `ANTHROPIC_API_KEY` | API key for chat backend |
-| `LLM_MODEL` | LLM model for chat (default: claude-sonnet-4-20250514) |
-
-## MCP Tools (for AI agents)
+## MCP Tools
 
 | Tool | Parameters | Purpose |
 |------|-----------|---------|

--- a/src/scitex_app/_skills/scitex-app/app-lifecycle.md
+++ b/src/scitex_app/_skills/scitex-app/app-lifecycle.md
@@ -1,0 +1,235 @@
+---
+name: app-lifecycle
+description: End-to-end guide for creating a SciTeX app — scaffold, develop, validate, dev-install, test, submit. Use when creating a new app from scratch.
+---
+
+# App Lifecycle — From Scaffold to Published
+
+Complete walkthrough for creating a SciTeX workspace app.
+
+## Prerequisites
+
+```bash
+pip install scitex-app scitex-ui
+```
+
+## Step 1: Scaffold
+
+```bash
+mkdir my-app && cd my-app
+scitex-app app init . --name my_app --frontend react
+```
+
+This creates ~20 files:
+```
+my_app/
+  _django/
+    __init__.py
+    apps.py          # MyAppConfig(ScitexAppConfig)
+    views.py         # editor_page + api_dispatch
+    urls.py          # scitex_urlpatterns(views)
+    manifest.json    # App metadata
+    frontend/
+      src/
+        bridge/
+          bridge-init.ts    # Entry point (auto-discovered)
+          MountPoint.ts     # React root mount
+        components/         # Your React components
+        store/              # Zustand state
+        api/                # Fetch wrappers
+  src/                      # Python core logic (no Django)
+  tests/
+  pyproject.toml
+  README.md
+```
+
+## Step 2: Edit manifest.json
+
+```json
+{
+  "name": "My App",
+  "slug": "my_app",
+  "label": "My App",
+  "version": "0.1.0",
+  "icon": "fas fa-flask",
+  "standalone": false,
+  "frontend_type": "react",
+  "privileges": [
+    {"type": "filesystem", "scope": "project"},
+    {"type": "network", "scope": "none"},
+    {"type": "api", "scope": "scitex"}
+  ],
+  "dependencies": ["scitex>=1.0"],
+  "bridge": {
+    "entry": "src/bridge/bridge-init.ts",
+    "source_root": "src"
+  }
+}
+```
+
+Required: `name`, `slug`, `label`, `version`, `icon`
+
+## Step 3: Implement
+
+### Backend (views.py)
+
+```python
+from scitex_app._django import scitex_editor_page, scitex_api_dispatch
+
+editor_page = scitex_editor_page(static_dir=STATIC_DIR)
+
+def _get_editor(request):
+    # Return your app's context object
+    return {"project": request.project}
+
+api_dispatch = scitex_api_dispatch(
+    handlers={
+        "load": lambda req, editor: JsonResponse({"data": "..."}),
+        "save": lambda req, editor: JsonResponse({"ok": True}),
+    },
+    get_editor=_get_editor,
+)
+```
+
+### Frontend (bridge-init.ts)
+
+```typescript
+import "scitex-ui/css/app.css";
+import { mountMyApp } from "./MountPoint";
+
+function init(): void {
+  const mount = document.getElementById("app-mount");
+  if (!mount) return;
+  mountMyApp(mount);
+}
+
+// Auto-init
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init);
+} else {
+  init();
+}
+```
+
+### Use scitex-ui components
+
+```typescript
+import { DataTable } from "scitex-ui/react/app";
+import { usePanelResize } from "scitex-ui/react/app";
+import { FileBrowser } from "scitex-ui/react/app";
+```
+
+### Use scitex-app file SDK
+
+```python
+from scitex_app.sdk import get_files
+
+files = get_files("./project")
+content = files.read("data/config.yaml")
+files.write("output/result.csv", csv_text)
+```
+
+## Step 4: Validate
+
+```bash
+scitex-app app validate .
+```
+
+Checks:
+- manifest.json has required fields
+- `_django/views.py` and `_django/urls.py` exist
+- No CSS targeting shell selectors (`#scitex-ai-panel`, `.stx-shell-*`, etc.)
+- No dangerous JS (`eval(`, `document.cookie`, etc.)
+- Bundle size < 50 MB
+- Privilege types and scopes are valid
+
+## Step 5: Dev-Install
+
+```bash
+scitex-app app dev-install . --server http://127.0.0.1:8000
+```
+
+This:
+1. Creates a `DevInstallation` record in the database
+2. Copies your app to the server's dev apps directory
+3. Registers it in the workspace sidebar (for your user only)
+
+## Step 6: Test in Browser
+
+1. Navigate to `http://127.0.0.1:8000/`
+2. Your app should appear in the sidebar
+3. Click it — the module pane loads your app's content
+4. Test all functionality: API calls, file operations, UI components
+
+## Step 7: Submit for Publication
+
+```bash
+scitex-app app submit .
+```
+
+This creates a PR to the SciTeX app registry. After review + approval:
+- App appears in the public catalog
+- Users can install it from the Apps page
+- It gets its own sidebar tab when installed
+
+## Reference Implementation
+
+Study figrecipe for a complete working example:
+
+```
+~/proj/figrecipe/src/figrecipe/_django/          # Django patterns
+~/proj/figrecipe/src/figrecipe/_django/frontend/  # React + bridge
+~/proj/figrecipe/src/figrecipe/_django/manifest.json  # Manifest example
+```
+
+## Common Patterns
+
+### Embedded vs Standalone
+
+```typescript
+// bridge-init.ts
+const isEmbedded = !!document.getElementById("workspace-content");
+if (isEmbedded) {
+  // Running inside scitex-cloud workspace
+  mountApp(document.getElementById("app-mount"));
+} else {
+  // Running standalone (scitex-app serve)
+  mountApp(document.getElementById("root"));
+}
+```
+
+### Panel Resize (scitex-ui)
+
+```typescript
+import { usePanelResize } from "scitex-ui/react/app";
+
+function MyEditor() {
+  const { leftWidth, rightWidth, resizerProps } = usePanelResize({
+    storageKey: "myapp-panel",
+    defaultLeftPercent: 30,
+  });
+  return (
+    <div style={{ display: "flex" }}>
+      <div style={{ width: leftWidth }}>Sidebar</div>
+      <div {...resizerProps} />
+      <div style={{ width: rightWidth }}>Main</div>
+    </div>
+  );
+}
+```
+
+### Bridge Events (cross-component communication)
+
+```typescript
+import { emitBridgeEvent, onBridgeEvent } from "scitex-ui";
+
+// Send
+emitBridgeEvent("myapp", "file-opened", { path: "/data/config.yaml" });
+
+// Listen
+onBridgeEvent("myapp", "file-opened", (detail) => {
+  console.log("Opened:", detail.path);
+});
+```
+
+# EOF

--- a/src/scitex_app/_skills/scitex-app/app-lifecycle.md
+++ b/src/scitex_app/_skills/scitex-app/app-lifecycle.md
@@ -1,235 +1,215 @@
 ---
 name: app-lifecycle
-description: End-to-end guide for creating a SciTeX app — scaffold, develop, validate, dev-install, test, submit. Use when creating a new app from scratch.
+description: App scaffolding, validation, dev-install, and submission API. init_app(), validate(), AppValidator, ValidationResult, and the full end-to-end workflow.
 ---
 
-# App Lifecycle — From Scaffold to Published
+# App Lifecycle
 
-Complete walkthrough for creating a SciTeX workspace app.
+Full lifecycle for SciTeX workspace apps: scaffold → validate → dev-install → submit.
 
-## Prerequisites
+## init_app()
 
-```bash
-pip install scitex-app scitex-ui
+```python
+from scitex_app.appmaker import init_app
+
+def init_app(
+    target_dir: str | Path,
+    name: str,
+    *,
+    label: str = "",
+    icon: str = "fas fa-puzzle-piece",
+    description: str = "",
+    manifest: Optional[dict] = None,
+    license_id: str = "AGPL-3.0",
+    overwrite: bool = False,
+    frontend_type: str = "html",   # "html" or "react"
+) -> list[str]
 ```
 
-## Step 1: Scaffold
+Generates complete app boilerplate. Returns list of relative paths created. Skips existing files unless `overwrite=True`.
 
-```bash
-mkdir my-app && cd my-app
-scitex-app app init . --name my_app --frontend react
+```python
+from scitex_app.appmaker import init_app
+from pathlib import Path
+
+created = init_app(
+    target_dir=Path("./my_awesome_app"),
+    name="my_awesome_app",          # must end with _app or -app
+    label="My Awesome App",
+    icon="fas fa-flask",
+    description="A SciTeX workspace app.",
+    frontend_type="html",           # or "react" for React+Vite+Zustand
+)
+print(f"Created {len(created)} files")
 ```
 
-This creates ~20 files:
+### Generated files (HTML frontend, ~17 files)
+
 ```
-my_app/
-  _django/
-    __init__.py
-    apps.py          # MyAppConfig(ScitexAppConfig)
-    views.py         # editor_page + api_dispatch
-    urls.py          # scitex_urlpatterns(views)
-    manifest.json    # App metadata
-    frontend/
-      src/
-        bridge/
-          bridge-init.ts    # Entry point (auto-discovered)
-          MountPoint.ts     # React root mount
-        components/         # Your React components
-        store/              # Zustand state
-        api/                # Fetch wrappers
-  src/                      # Python core logic (no Django)
-  tests/
-  pyproject.toml
-  README.md
+__init__.py
+apps.py
+views.py
+urls.py
+tests.py
+skill.py
+manifest.json
+templates/<name>/index.html
+templates/<name>/index_partial.html
+static/<name>/css/<name>.css
+.agents/agents.json
+AGENTS.md
+docs/PLATFORM.md
+README.md
+LICENSE
+.gitignore
+pyproject.toml
+_cli.py
 ```
 
-## Step 2: Edit manifest.json
+React frontend (`frontend_type="react"`) adds additional files: `package.json`, `vite.config.js`, `src/bridge/bridge-init.ts`, `src/components/`, `src/store/`.
+
+### manifest.json required fields
 
 ```json
 {
-  "name": "My App",
-  "slug": "my_app",
-  "label": "My App",
+  "name": "my_awesome_app",
+  "slug": "my-awesome-app",
+  "label": "My Awesome App",
   "version": "0.1.0",
   "icon": "fas fa-flask",
-  "standalone": false,
-  "frontend_type": "react",
-  "privileges": [
-    {"type": "filesystem", "scope": "project"},
-    {"type": "network", "scope": "none"},
-    {"type": "api", "scope": "scitex"}
-  ],
-  "dependencies": ["scitex>=1.0"],
-  "bridge": {
-    "entry": "src/bridge/bridge-init.ts",
-    "source_root": "src"
-  }
+  "description": "...",
+  "privileges": []
 }
 ```
 
-Required: `name`, `slug`, `label`, `version`, `icon`
+Required fields: `name`, `slug`, `label`, `version`, `icon`.
 
-## Step 3: Implement
+### Privilege types
 
-### Backend (views.py)
+```json
+"privileges": [
+  {"type": "filesystem", "scope": "project"},
+  {"type": "network",    "scope": "none"},
+  {"type": "api",        "scope": "scitex"}
+]
+```
+
+| Type | Valid scopes |
+|------|-------------|
+| `filesystem` | `project`, `readonly`, `none` |
+| `network` | `none`, `allowlist` |
+| `api` | `scitex`, `llm`, `none` |
+
+## validate()
 
 ```python
-from scitex_app._django import scitex_editor_page, scitex_api_dispatch
+from scitex_app.appmaker import validate
 
-editor_page = scitex_editor_page(static_dir=STATIC_DIR)
-
-def _get_editor(request):
-    # Return your app's context object
-    return {"project": request.project}
-
-api_dispatch = scitex_api_dispatch(
-    handlers={
-        "load": lambda req, editor: JsonResponse({"data": "..."}),
-        "save": lambda req, editor: JsonResponse({"ok": True}),
-    },
-    get_editor=_get_editor,
-)
+errors = validate(app_dir)   # list[str], empty = passed
+if not errors:
+    print("Ready for submission")
+else:
+    for e in errors:
+        print(f"ERROR: {e}")
 ```
 
-### Frontend (bridge-init.ts)
+Thin wrapper around `AppValidator` — returns error strings directly.
 
-```typescript
-import "scitex-ui/css/app.css";
-import { mountMyApp } from "./MountPoint";
+## AppValidator
 
-function init(): void {
-  const mount = document.getElementById("app-mount");
-  if (!mount) return;
-  mountMyApp(mount);
-}
-
-// Auto-init
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", init);
-} else {
-  init();
-}
-```
-
-### Use scitex-ui components
-
-```typescript
-import { DataTable } from "scitex-ui/react/app";
-import { usePanelResize } from "scitex-ui/react/app";
-import { FileBrowser } from "scitex-ui/react/app";
-```
-
-### Use scitex-app file SDK
+Full validation pipeline. Pure Python, no Django dependency.
 
 ```python
-from scitex_app.sdk import get_files
+from scitex_app.validator import AppValidator
 
-files = get_files("./project")
-content = files.read("data/config.yaml")
-files.write("output/result.csv", csv_text)
+validator = AppValidator("/path/to/myapp")
+result = validator.validate()
+
+print(result.passed)    # bool
+for err in result.errors:
+    print(f"ERROR: {err}")
+for warn in result.warnings:
+    print(f"WARN:  {warn}")
 ```
 
-## Step 4: Validate
+```python
+class AppValidator:
+    def __init__(
+        self,
+        app_path: str | Path,
+        max_bundle_size: int = 50 * 1024 * 1024,  # 50 MB default
+    )
+
+    def validate(self) -> ValidationResult
+    def validate_manifest(self) -> None
+    def validate_structure(self) -> None
+    def validate_css(self) -> None
+    def validate_js(self) -> None
+    def validate_bundle_size(self) -> None
+    def validate_privileges(self) -> None
+```
+
+### What each check validates
+
+| Check | What it does |
+|-------|-------------|
+| `validate_manifest` | manifest.json exists, has required fields, valid semver version |
+| `validate_structure` | `_django/views.py` and `_django/urls.py` exist |
+| `validate_css` | CSS does not target reserved shell selectors |
+| `validate_js` | JS/TS/JSX/TSX has no dangerous patterns |
+| `validate_bundle_size` | Total file size is under `max_bundle_size` |
+| `validate_privileges` | Declared privileges use valid types and scopes |
+
+### ValidationResult
+
+```python
+@dataclass
+class ValidationResult:
+    passed: bool
+    errors: List[str]
+    warnings: List[str]
+    privileges: List[dict]
+    manifest: Optional[dict]
+```
+
+`result.add_error(msg)` — appends to errors and sets `passed = False`.
+`result.add_warning(msg)` — appends to warnings, does not fail.
+
+### Forbidden CSS selectors
+
+Apps must not target: `#scitex-ai-panel`, `#main-content`, `.ws-module-pane`, `.workspace-header`, `.workspace-sidebar`, `.stx-shell-*`, `#workspace-container`, `.ws-app-sidebar`.
+
+### Forbidden JS patterns
+
+`eval(`, `Function(`, `document.cookie`, `window.parent`, `window.top`, `__import__`, `os.system`, `subprocess`, `exec(`.
+
+## End-to-end workflow
 
 ```bash
+# 1. Scaffold
+scitex-app app init . --name my_app
+
+# 2. Develop (edit views.py, templates/, etc.)
+
+# 3. Validate
 scitex-app app validate .
-```
 
-Checks:
-- manifest.json has required fields
-- `_django/views.py` and `_django/urls.py` exist
-- No CSS targeting shell selectors (`#scitex-ai-panel`, `.stx-shell-*`, etc.)
-- No dangerous JS (`eval(`, `document.cookie`, etc.)
-- Bundle size < 50 MB
-- Privilege types and scopes are valid
-
-## Step 5: Dev-Install
-
-```bash
+# 4. Dev-install on running SciTeX Cloud instance
+export SCITEX_API_TOKEN="your-jwt-token"
 scitex-app app dev-install . --server http://127.0.0.1:8000
-```
 
-This:
-1. Creates a `DevInstallation` record in the database
-2. Copies your app to the server's dev apps directory
-3. Registers it in the workspace sidebar (for your user only)
+# 5. Test in browser at http://127.0.0.1:8000/
 
-## Step 6: Test in Browser
-
-1. Navigate to `http://127.0.0.1:8000/`
-2. Your app should appear in the sidebar
-3. Click it — the module pane loads your app's content
-4. Test all functionality: API calls, file operations, UI components
-
-## Step 7: Submit for Publication
-
-```bash
+# 6. Submit for public review
 scitex-app app submit .
 ```
 
-This creates a PR to the SciTeX app registry. After review + approval:
-- App appears in the public catalog
-- Users can install it from the Apps page
-- It gets its own sidebar tab when installed
+## Reference implementation
 
-## Reference Implementation
-
-Study figrecipe for a complete working example:
+Study `figrecipe` for a complete working example:
 
 ```
-~/proj/figrecipe/src/figrecipe/_django/          # Django patterns
+~/proj/figrecipe/src/figrecipe/_django/           # Django views + urls
 ~/proj/figrecipe/src/figrecipe/_django/frontend/  # React + bridge
-~/proj/figrecipe/src/figrecipe/_django/manifest.json  # Manifest example
+~/proj/figrecipe/src/figrecipe/_django/manifest.json
 ```
-
-## Common Patterns
-
-### Embedded vs Standalone
-
-```typescript
-// bridge-init.ts
-const isEmbedded = !!document.getElementById("workspace-content");
-if (isEmbedded) {
-  // Running inside scitex-cloud workspace
-  mountApp(document.getElementById("app-mount"));
-} else {
-  // Running standalone (scitex-app serve)
-  mountApp(document.getElementById("root"));
-}
-```
-
-### Panel Resize (scitex-ui)
-
-```typescript
-import { usePanelResize } from "scitex-ui/react/app";
-
-function MyEditor() {
-  const { leftWidth, rightWidth, resizerProps } = usePanelResize({
-    storageKey: "myapp-panel",
-    defaultLeftPercent: 30,
-  });
-  return (
-    <div style={{ display: "flex" }}>
-      <div style={{ width: leftWidth }}>Sidebar</div>
-      <div {...resizerProps} />
-      <div style={{ width: rightWidth }}>Main</div>
-    </div>
-  );
-}
-```
-
-### Bridge Events (cross-component communication)
-
-```typescript
-import { emitBridgeEvent, onBridgeEvent } from "scitex-ui";
-
-// Send
-emitBridgeEvent("myapp", "file-opened", { path: "/data/config.yaml" });
-
-// Listen
-onBridgeEvent("myapp", "file-opened", (detail) => {
-  console.log("Opened:", detail.path);
-});
-```
-
-# EOF

--- a/src/scitex_app/_skills/scitex-app/app-registration.md
+++ b/src/scitex_app/_skills/scitex-app/app-registration.md
@@ -1,0 +1,105 @@
+---
+name: app-registration
+description: How a SciTeX app registers with the workspace sidebar — manifest.json to ModuleConfig to sidebar tab. Use when building apps that need to appear in the workspace.
+---
+
+# App Registration — How Apps Appear in the Workspace
+
+When a SciTeX app is installed, it appears as a tab in the workspace sidebar.
+This document explains the registration flow.
+
+## Registration Flow
+
+```
+manifest.json → ModuleConfig dataclass → register_module() → workspace sidebar
+```
+
+There are two paths:
+
+### Path 1: Dev Install (during development)
+
+```bash
+scitex-app app dev-install . --server http://127.0.0.1:8000
+```
+
+This creates a `DevInstallation` record in the database:
+- `source_owner`: your username
+- `source_repo`: repo name
+- `module_name`: `dev__<owner>__<repo>` (auto-generated)
+
+At startup, `build_module_config(dev_install)` creates a `ModuleConfig` and
+registers it. The app appears in the sidebar for that user only.
+
+### Path 2: Published App (after submission + approval)
+
+```bash
+scitex-app app submit .
+```
+
+This creates a PR to the app registry. After approval:
+1. An `AppsModule` record is created with `visibility="public"`
+2. At Django startup, `load_approved_apps()` iterates all public modules
+3. For each, `load_single_app()` reads manifest.json and builds `ModuleConfig`
+4. `register_module(config)` adds it to the global registry
+5. The context processor includes it in `workspace_modules` for templates
+
+## ModuleConfig Fields (what matters for apps)
+
+```python
+ModuleConfig(
+    name="myapp",               # URL slug → /apps/myapp/
+    label="My App",             # Display name in sidebar
+    app_name="apps_app",        # Always "apps_app" for external apps
+    icon_fa="fas fa-flask",     # FontAwesome icon class
+    partial_template="apps_app/user_apps/myapp_partial.html",
+    context_builder="apps.workspace.apps_app.services.app_context.build_user_app_context",
+    order=90,                   # After built-in modules (20-50)
+    default_enabled=False,      # User must install from catalog
+    ai_hint="Short description for LLM context",
+    license="AGPL-3.0",        # SPDX identifier
+)
+```
+
+### Fields you control via manifest.json
+
+| manifest.json field | → ModuleConfig field | Purpose |
+|---------------------|---------------------|---------|
+| `slug` | `name` | URL path segment |
+| `name` | `label` | Sidebar display name |
+| `icon` | `icon_fa` | FontAwesome icon class |
+| `version` | (stored in AppsModule) | Semantic version |
+| `privileges` | `privileges` | Declared capabilities |
+
+### Fields set automatically
+
+| ModuleConfig field | Value | Why |
+|-------------------|-------|-----|
+| `app_name` | `"apps_app"` | All external apps use the apps infrastructure |
+| `partial_template` | `"apps_app/user_apps/{name}_partial.html"` | Standard partial location |
+| `context_builder` | `"...build_user_app_context"` | Standard context for external apps |
+| `order` | `90` | External apps appear after built-ins |
+
+## How the Sidebar Renders It
+
+The workspace context processor (`context_processors.py`) calls `get_all_modules()`
+which returns all registered `ModuleConfig` objects. The template iterates:
+
+```html
+{% for mod in workspace_modules %}
+    <a href="{{ mod.get_url }}" class="sidebar-item" data-module="{{ mod.name }}">
+        <i class="{{ mod.icon_fa }}"></i>
+        <span>{{ mod.label }}</span>
+    </a>
+{% endfor %}
+```
+
+`get_url()` returns `/apps/{name}/` by default.
+
+## Key Source Files
+
+- `scitex-cloud/apps/infra/workspace_app/registry.py` — ModuleConfig + register_module()
+- `scitex-cloud/apps/workspace/apps_app/services/app_loader.py` — load_approved_apps()
+- `scitex-cloud/apps/workspace/apps_app/services/dev_app_loader.py` — build_module_config()
+- `scitex-cloud/apps/infra/workspace_app/context_processors.py` — injects into templates
+
+# EOF

--- a/src/scitex_app/_skills/scitex-app/backend-sdk.md
+++ b/src/scitex_app/_skills/scitex-app/backend-sdk.md
@@ -1,0 +1,290 @@
+---
+name: backend-sdk
+description: Backend SDK reference — FilesBackend protocol, Django integration, manifest schema, app validation, path resolution
+---
+
+#!/usr/bin/env python3
+# scitex_app — AI Agent Developer Guide
+# Timestamp: 2026-03-18
+# Audience: AI coding agents building SciTeX apps
+
+---
+
+## 1. Quick Start
+
+```python
+from scitex_app.sdk import get_files
+
+# Local: pass a directory path
+files = get_files("./my_project")
+content = files.read("data/config.yaml")
+files.write("output/result.json", '{"ok": true}')
+
+# Cloud: auto-detected when SCITEX_API_TOKEN is set
+import os
+os.environ["SCITEX_API_TOKEN"] = "your-token"
+os.environ["SCITEX_API_URL"] = "https://scitex.ai"
+files = get_files()  # routes to cloud REST API
+```
+
+Auto-detection order:
+1. Explicit `backend=` argument wins
+2. `SCITEX_API_TOKEN` env var → cloud backend
+3. Fallback → local `FileSystemBackend`
+
+---
+
+## 2. FilesBackend Protocol
+
+`FilesBackend` is a `typing.Protocol` — no inheritance needed, just implement these 7 methods.
+
+```python
+from scitex_app.sdk import FilesBackend
+from typing import List, Optional, Union
+
+class MyBackend:                                        # no inheritance required
+    def read(self, path: str, *, binary: bool = False) -> Union[str, bytes]: ...
+    def write(self, path: str, content: Union[str, bytes]) -> None: ...
+    def list(self, directory: str = "", *, extensions: Optional[List[str]] = None) -> List[str]: ...
+    def exists(self, path: str) -> bool: ...
+    def delete(self, path: str) -> None: ...            # raises FileNotFoundError
+    def rename(self, old_path: str, new_path: str) -> None: ...  # raises FileNotFoundError / FileExistsError
+    def copy(self, src_path: str, dest_path: str) -> None: ...   # raises FileNotFoundError
+```
+
+Registering a custom backend:
+
+```python
+from scitex_app.sdk import register_backend
+
+def my_s3_factory(root, **kwargs) -> MyBackend:
+    return MyBackend(root, **kwargs)
+
+register_backend("s3", my_s3_factory)
+files = get_files(backend="s3", bucket="my-bucket")
+```
+
+---
+
+## 3. Django Integration
+
+### AppConfig
+
+```python
+# myapp/_django/apps.py
+from scitex_app._django import ScitexAppConfig
+
+class MyAppConfig(ScitexAppConfig):
+    name = "myapp._django"
+    label = "myapp"
+    verbose_name = "My App"
+
+# Properties available after loading manifest.json:
+# config.manifest        -> dict (raw manifest)
+# config.app_slug        -> str  (manifest["slug"])
+# config.app_version     -> str  (manifest["version"])
+# config.app_icon        -> str  (manifest["icon"])
+# config.is_standalone   -> bool (manifest["standalone"], default False)
+# config.frontend_type   -> str  (manifest["frontend_type"], default "django")
+# config.validate_manifest() -> List[str]  (empty = valid)
+```
+
+### View factories
+
+```python
+# myapp/_django/views.py
+from pathlib import Path
+from scitex_app._django import scitex_editor_page, scitex_api_dispatch
+
+STATIC_DIR = Path(__file__).parent / "static" / "myapp"
+
+# Serves React SPA index.html; returns 503 if build missing
+editor_page = scitex_editor_page(
+    static_dir=STATIC_DIR,
+    index_file="index.html",                    # default
+    fallback_message="Run: npm run build",      # default
+)
+
+def _get_editor(request):
+    """Return your app's editor/context object, or None."""
+    ...
+
+api_dispatch = scitex_api_dispatch(
+    handlers={
+        "load":   lambda req, editor: ...,      # JsonResponse
+        "save":   lambda req, editor: ...,
+    },
+    parameterized=[
+        ("file/", lambda req, editor, param: ...),  # /file/<anything>
+    ],
+    no_editor_endpoints={"health"},             # endpoints that skip editor check
+    get_editor=_get_editor,
+)
+```
+
+### URL patterns
+
+```python
+# myapp/_django/urls.py
+from scitex_app._django import scitex_urlpatterns
+from . import views
+
+urlpatterns = scitex_urlpatterns(views)
+# Generates:
+#   ""                  -> views.editor_page  (name="editor")
+#   "<path:endpoint>"   -> views.api_dispatch (name="api")
+```
+
+---
+
+## 4. Manifest Schema
+
+```json
+{
+  "name":    "My App",
+  "slug":    "myapp",
+  "label":   "myapp",
+  "version": "0.1.0",
+  "icon":    "fas fa-flask",
+
+  "standalone":    false,
+  "frontend_type": "react",
+
+  "privileges": [
+    {"type": "filesystem", "scope": "project"},
+    {"type": "network",    "scope": "none"},
+    {"type": "api",        "scope": "scitex"}
+  ],
+  "dependencies": ["scitex>=1.0"],
+  "bridge": {}
+}
+```
+
+Required fields: `name`, `slug`, `label`, `version`, `icon`
+
+Valid privilege combinations:
+
+| type         | valid scopes                    |
+|--------------|---------------------------------|
+| `filesystem` | `project`, `readonly`, `none`   |
+| `network`    | `none`, `allowlist`             |
+| `api`        | `scitex`, `llm`, `none`         |
+
+---
+
+## 5. App Validation
+
+```python
+from scitex_app.validator import AppValidator
+
+validator = AppValidator("/path/to/myapp")      # accepts str or Path
+result = validator.validate()
+
+print(result.passed)     # bool
+print(result.errors)     # List[str] — fail conditions
+print(result.warnings)   # List[str] — advisory notices
+print(result.manifest)   # dict | None
+```
+
+Validation pipeline (runs in order):
+1. `validate_manifest()` — required fields, valid JSON, semver version
+2. `validate_structure()` — `_django/views.py` and `_django/urls.py` present
+3. `validate_css()` — no CSS targeting shell selectors (see below)
+4. `validate_js()` — no dangerous JS patterns
+5. `validate_bundle_size()` — total size < 50 MB (configurable via `max_bundle_size`)
+6. `validate_privileges()` — privilege types and scopes must be valid
+
+Shell selectors apps must NOT target:
+`#scitex-ai-panel`, `#main-content`, `.ws-module-pane`, `.workspace-header`,
+`.workspace-sidebar`, `.stx-shell-*`, `#workspace-container`, `.ws-app-sidebar`
+
+Dangerous JS patterns blocked:
+`eval(`, `Function(`, `document.cookie`, `window.parent`, `window.top`,
+`__import__`, `os.system`, `subprocess`, `exec(`
+
+Skipped directories during scanning: `node_modules`, `dist`, `.vite`, `_docs`,
+`__pycache__`, `assets`
+
+---
+
+## 6. Path Resolution
+
+```python
+from scitex_app.paths import (
+    get_base_dir,
+    resolve_user_project_dir,
+    resolve_published_project_dir,
+    resolve_manifest,
+    resolve_template_dir,
+    resolve_static_dir,
+    find_partial_template,
+    parse_dev_module_name,
+    safe_iterdir,
+    validate_project_structure,
+)
+
+# Base dir: explicit arg > SCITEX_BASE_DIR env var > ValueError
+base = get_base_dir()                         # reads SCITEX_BASE_DIR
+base = get_base_dir("/data/scitex")           # explicit
+
+# User dev-app: base_dir/data/users/<owner>/proj/<repo>/
+project = resolve_user_project_dir("alice", "my-app", base_dir=base)
+
+# Published project: base_dir/data/projects/<slug>/
+project = resolve_published_project_dir("my-app-v1", base_dir=base)
+
+# Manifest, templates, static from project dir
+manifest = resolve_manifest(project)          # dict (empty if missing/invalid)
+tpl_dir  = resolve_template_dir(project)      # Path | None
+static   = resolve_static_dir(project)        # Path | None
+
+# Find partial template (flat or nested layout)
+tpl = find_partial_template(tpl_dir)          # searches for index_partial.html
+
+# Parse dev module name convention: dev__<owner>__<repo>
+owner, repo = parse_dev_module_name("dev__alice__my-app")  # -> ("alice", "my-app")
+
+# Validate project structure (has templates/ + index_partial.html)
+ok, msg = validate_project_structure(project)
+
+# Safe directory iteration (skips hidden files, handles permission errors)
+for entry in safe_iterdir(project):
+    print(entry)
+```
+
+Directory layout convention:
+
+```
+base_dir/
+  data/
+    users/<owner>/proj/<repo>/    # dev apps
+      manifest.json
+      templates/<app>/index_partial.html
+      static/<app>/...
+    projects/<slug>/              # published apps
+      manifest.json
+```
+
+---
+
+## 7. Minimal App Checklist
+
+```
+myapp/
+  _django/
+    __init__.py
+    apps.py      # class MyAppConfig(ScitexAppConfig)
+    views.py     # editor_page = scitex_editor_page(...); api_dispatch = scitex_api_dispatch(...)
+    urls.py      # urlpatterns = scitex_urlpatterns(views)
+    manifest.json
+  src/           # Python core logic (no Django)
+```
+
+- manifest.json must have all 5 required fields
+- No CSS targeting shell selectors
+- No dangerous JS patterns
+- `_django/views.py` and `_django/urls.py` required for platform integration
+- Use `get_files()` for all file I/O — never `open()` directly in app logic
+- **Packaging**: Apps with a `bridge` key in manifest.json must keep `_django/frontend/src/` in their source tree. scitex-cloud discovers bridges by scanning sibling directories. Use an `[app]` optional extra for platform Python deps. In CI, clone the repo as a sibling.
+
+# EOF

--- a/src/scitex_app/_skills/scitex-app/cli.md
+++ b/src/scitex_app/_skills/scitex-app/cli.md
@@ -1,0 +1,169 @@
+---
+name: cli
+description: scitex-app CLI — file operations, app lifecycle (init/validate/dev-install/submit), MCP server, and Python API introspection.
+---
+
+# CLI Reference
+
+Entry point: `scitex-app` (installed via `pip install scitex-app[cli]`)
+
+Requires `click` and `rich`. Install with: `pip install scitex-app[cli]`
+
+```
+Usage: scitex-app [OPTIONS] COMMAND [ARGS]...
+
+  SciTeX App SDK — write-once interface for local + cloud apps.
+
+Options:
+  --version          Show version and exit.
+  --help-recursive   Show help for all subcommands.
+  -h, --help         Show this message and exit.
+```
+
+## App Development
+
+### app init
+
+```bash
+scitex-app app init [TARGET_DIR] [OPTIONS]
+```
+
+Scaffold a complete SciTeX app.
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `--name`, `-n` | directory name | Python module name (must end with `_app`) |
+| `--label`, `-l` | derived from name | Human-readable label |
+| `--icon`, `-i` | `fas fa-puzzle-piece` | Font Awesome icon class |
+| `--description`, `-d` | `""` | Short description |
+| `--frontend`, `-f` | `html` | Frontend type: `html` or `react` |
+| `--overwrite` | false | Overwrite existing files |
+
+```bash
+scitex-app app init .
+scitex-app app init /path/to/my_app --name my_awesome_app
+scitex-app app init . -n demo_app -l "Demo" -i "fas fa-flask"
+scitex-app app init . --frontend react
+```
+
+Name is auto-suffixed with `_app` if missing.
+
+### app validate
+
+```bash
+scitex-app app validate [APP_DIR]
+```
+
+Validate app for submission readiness. Exits 0 on pass, 1 on failure.
+
+```bash
+scitex-app app validate .
+scitex-app app validate /path/to/my_app
+```
+
+### app dev-install
+
+```bash
+scitex-app app dev-install [APP_DIR] [OPTIONS]
+```
+
+Validate locally, then call the SciTeX Cloud dev-install API. App appears in workspace sidebar immediately.
+
+| Option | Default | Env var | Purpose |
+|--------|---------|---------|---------|
+| `--server`, `-s` | `http://127.0.0.1:8000` | `SCITEX_SERVER_URL` | Server URL |
+| `--token`, `-t` | — | `SCITEX_API_TOKEN` | JWT access token (required) |
+| `--owner`, `-o` | auto-detected | — | Gitea username |
+| `--repo`, `-r` | from manifest | — | Gitea repo name |
+
+```bash
+scitex-app app dev-install .
+scitex-app app dev-install . --server http://my-server:8000
+```
+
+### app submit
+
+```bash
+scitex-app app submit [APP_DIR] [OPTIONS]
+```
+
+Submit app for review and public listing. Opens a PR on scitex-apps registry.
+
+| Option | Default | Env var | Purpose |
+|--------|---------|---------|---------|
+| `--server`, `-s` | `http://127.0.0.1:8000` | `SCITEX_SERVER_URL` | Server URL |
+| `--token`, `-t` | — | `SCITEX_API_TOKEN` | JWT token (required) |
+
+```bash
+scitex-app app submit .
+scitex-app app submit /path/to/my_app --server https://scitex.example.com
+```
+
+## File Operations
+
+All file commands accept `--root` (default `.`) and `--json` for machine-readable output.
+
+```bash
+scitex-app read <path> [--root DIR] [--binary] [--json]
+scitex-app write <path> [CONTENT] [--root DIR] [--stdin] [--json] [--dry-run]
+scitex-app list [DIRECTORY] [--root DIR] [--ext EXT]... [--json]
+scitex-app exists <path> [--root DIR] [--json]
+scitex-app delete <path> [--root DIR] [--json] [--dry-run]
+scitex-app rename <old-path> <new-path> [--root DIR] [--json] [--dry-run]
+scitex-app copy <src-path> <dest-path> [--root DIR] [--json] [--dry-run]
+```
+
+```bash
+# Read a file
+scitex-app read config.yaml
+scitex-app read data.bin --binary
+
+# Write content
+scitex-app write output.txt "hello world"
+echo "data" | scitex-app write output.txt --stdin
+scitex-app write output.txt "test" --dry-run
+
+# List files
+scitex-app list
+scitex-app list data --ext .yaml --ext .json
+scitex-app list --json
+
+# Check existence (exit code 0=exists, 1=missing)
+scitex-app exists config.yaml
+
+# Delete, rename, copy with dry-run preview
+scitex-app delete temp.txt --dry-run
+scitex-app rename old.txt new.txt
+scitex-app copy src.txt dst.txt --dry-run
+```
+
+## Integration
+
+### MCP Server
+
+```bash
+scitex-app mcp start             # Start MCP server (stdio transport)
+scitex-app mcp list-tools        # List available MCP tools
+scitex-app mcp list-tools -v     # Verbose with parameter descriptions
+scitex-app mcp doctor            # Check MCP configuration health
+scitex-app mcp installation      # Show installation instructions
+```
+
+### Python API Introspection
+
+```bash
+scitex-app list-python-apis              # List all public Python APIs
+scitex-app list-python-apis -v           # Verbose with signatures
+scitex-app list-python-apis --json       # Machine-readable JSON
+```
+
+## Documentation and Skills
+
+```bash
+scitex-app docs list             # List available documentation pages
+scitex-app docs get <page>       # Show a documentation page
+scitex-app skills list           # List skill pages
+scitex-app skills get <skill>    # Show a skill page
+```
+
+Requires `scitex-dev`: `pip install scitex-dev`

--- a/src/scitex_app/_skills/scitex-app/environment-vars.md
+++ b/src/scitex_app/_skills/scitex-app/environment-vars.md
@@ -1,0 +1,89 @@
+---
+name: environment-vars
+description: All environment variables used by scitex-app — storage, cloud API, standalone Django, and LLM configuration.
+---
+
+# Environment Variables
+
+## Storage and Path Resolution
+
+| Variable | Purpose | Used by |
+|----------|---------|---------|
+| `SCITEX_BASE_DIR` | Base directory for app path resolution | `scitex_app.paths.get_base_dir()` |
+| `SCITEX_WORKING_DIR` | Working directory for standalone file tree | `run_standalone()` |
+
+```bash
+export SCITEX_BASE_DIR=/data/scitex
+export SCITEX_WORKING_DIR=/home/user/projects
+```
+
+## Cloud API
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `SCITEX_API_TOKEN` | JWT token for cloud API authentication | — |
+| `SCITEX_API_URL` | Cloud API base URL | `http://127.0.0.1:8000` |
+| `SCITEX_SERVER_URL` | Server URL for `app dev-install` and `app submit` | `http://127.0.0.1:8000` |
+
+`SCITEX_API_TOKEN` is the trigger for automatic cloud backend selection in `get_files()`. When set, `get_files()` routes to the cloud backend instead of the local filesystem.
+
+```bash
+export SCITEX_API_TOKEN="eyJhbGci..."
+export SCITEX_API_URL="https://scitex.ai"
+export SCITEX_SERVER_URL="https://scitex.example.com"
+```
+
+## Standalone Django
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `DJANGO_SECRET_KEY` | Django secret key for standalone mode | `"scitex-standalone-dev-key"` |
+| `DJANGO_DEBUG` | Django debug mode | `"true"` |
+| `SCITEX_UI_STATIC` | Path to scitex-ui static files | auto-detected |
+
+```bash
+export DJANGO_SECRET_KEY="your-production-secret-key"
+export DJANGO_DEBUG="false"
+```
+
+## LLM / Chat
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `ANTHROPIC_API_KEY` | API key for Anthropic chat backend | — |
+| `LLM_MODEL` | LLM model identifier for chat features | `claude-sonnet-4-20250514` |
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+export LLM_MODEL="claude-opus-4-5"
+```
+
+## Usage Examples
+
+### Local development (default)
+
+No environment variables needed. `get_files("./project")` uses local filesystem.
+
+### Cloud-connected development
+
+```bash
+export SCITEX_API_TOKEN="your-jwt-token"
+export SCITEX_API_URL="https://scitex.ai"
+```
+
+Then `get_files()` (no arguments) routes through the cloud REST API.
+
+### Remote local server
+
+```bash
+export SCITEX_API_TOKEN="your-jwt-token"
+export SCITEX_API_URL="http://192.168.1.100:8000"
+```
+
+### Production standalone app
+
+```bash
+export DJANGO_SECRET_KEY="$(python -c 'import secrets; print(secrets.token_hex(50))')"
+export DJANGO_DEBUG="false"
+export SCITEX_WORKING_DIR="/data/user_projects"
+```

--- a/src/scitex_app/_skills/scitex-app/files-sdk.md
+++ b/src/scitex_app/_skills/scitex-app/files-sdk.md
@@ -1,0 +1,156 @@
+---
+name: files-sdk
+description: Core file operations SDK — get_files(), FilesBackend protocol, FileSystemBackend, build_tree(). Write-once API for local and cloud storage.
+---
+
+# Files SDK
+
+Write-once file I/O that auto-routes to local filesystem or cloud backend.
+
+## get_files()
+
+```python
+def get_files(
+    root: Optional[Union[str, Path]] = None,
+    *,
+    backend: Optional[str] = None,
+    **kwargs,
+) -> FilesBackend
+```
+
+Auto-detection order:
+1. `backend` kwarg specified → use that registered backend
+2. `SCITEX_API_TOKEN` env set → use "cloud" backend (auto-registers if needed)
+3. Otherwise → `FileSystemBackend(root or cwd)`
+
+```python
+from scitex_app.sdk import get_files
+
+# Local filesystem (default)
+files = get_files("./my_project")
+
+# Cloud (SCITEX_API_TOKEN must be set)
+files = get_files()
+
+# Explicit backend
+files = get_files(backend="s3", bucket="my-bucket")
+```
+
+Raises `KeyError` if a named backend is not registered.
+
+## FilesBackend Protocol
+
+Structural protocol (`typing.Protocol`) — backends implement these 7 methods without subclassing:
+
+```python
+class FilesBackend(Protocol):
+    def read(self, path: str, *, binary: bool = False) -> Union[str, bytes]: ...
+    def write(self, path: str, content: Union[str, bytes]) -> None: ...
+    def list(self, directory: str = "", *, extensions: Optional[List[str]] = None) -> List[str]: ...
+    def exists(self, path: str) -> bool: ...
+    def delete(self, path: str) -> None: ...
+    def rename(self, old_path: str, new_path: str) -> None: ...
+    def copy(self, src_path: str, dest_path: str) -> None: ...
+```
+
+All `path` arguments are relative to the backend's root namespace. Path traversal (`../`) is blocked.
+
+### read()
+
+```python
+content = files.read("data/config.yaml")          # str (UTF-8)
+data    = files.read("data/model.pt", binary=True) # bytes
+```
+
+Raises `FileNotFoundError` if path does not exist.
+
+### write()
+
+```python
+files.write("output/result.csv", csv_text)         # str content
+files.write("output/model.pt", model_bytes)        # bytes content
+```
+
+Creates parent directories automatically.
+
+### list()
+
+```python
+all_files  = files.list()                              # all in root
+yaml_files = files.list("config", extensions=[".yaml"])
+py_files   = files.list("src", extensions=[".py"])
+```
+
+Returns list of relative path strings. Only files, not directories.
+
+### exists() / delete() / rename() / copy()
+
+```python
+if files.exists("data/config.yaml"):
+    files.delete("data/old.csv")
+
+files.rename("output/draft.txt", "output/final.txt")  # raises FileExistsError if dest exists
+files.copy("templates/base.html", "output/base.html")
+```
+
+## register_backend()
+
+```python
+def register_backend(name: str, factory: Callable[..., FilesBackend]) -> None
+```
+
+Register a custom backend factory:
+
+```python
+from scitex_app.sdk import register_backend
+
+def my_s3_factory(root, *, bucket, **kwargs):
+    return MyS3Backend(bucket=bucket, prefix=root)
+
+register_backend("s3", my_s3_factory)
+files = get_files(backend="s3", bucket="my-bucket")
+```
+
+## FileSystemBackend
+
+Local-disk implementation included with scitex-app. Path traversal outside root is blocked.
+
+```python
+from scitex_app.sdk._filesystem import FileSystemBackend
+
+fs = FileSystemBackend("/path/to/root")
+print(fs.root)   # Path("/path/to/root")
+print(repr(fs))  # FileSystemBackend(/path/to/root)
+```
+
+## build_tree()
+
+```python
+def build_tree(
+    backend: FilesBackend,
+    directory: str = "",
+    *,
+    extensions: Optional[List[str]] = None,
+    skip_hidden: bool = True,
+    max_depth: int = 10,
+) -> List[Dict[str, Any]]
+```
+
+Builds a nested tree structure for file browser UIs.
+
+```python
+from scitex_app import build_tree
+from scitex_app.sdk import get_files
+
+files = get_files("./project")
+tree = build_tree(files, extensions=[".yaml", ".json"], max_depth=3)
+# [
+#   {"path": "config", "name": "config", "type": "directory",
+#    "children": [
+#      {"path": "config/settings.yaml", "name": "settings.yaml", "type": "file"}
+#    ]},
+#   {"path": "README.md", "name": "README.md", "type": "file"},
+# ]
+```
+
+Only non-empty directories are included. Hidden files (`.gitignore`, etc.) are skipped by default. Results are sorted case-insensitively.

--- a/src/scitex_app/_skills/scitex-app/paths.md
+++ b/src/scitex_app/_skills/scitex-app/paths.md
@@ -1,0 +1,162 @@
+---
+name: paths
+description: Path resolution utilities for SciTeX apps. get_base_dir(), resolve_user_project_dir(), resolve_published_project_dir(), resolve_manifest(), find_partial_template(), parse_dev_module_name().
+---
+
+# Path Resolution
+
+`scitex_app.paths` — Django-agnostic path utilities for SciTeX app directories.
+
+All functions accept an explicit `base_dir` parameter. When omitted, `SCITEX_BASE_DIR` env var is used.
+
+## Directory Layout
+
+```
+base_dir/
+  data/
+    users/<owner>/proj/<repo>/      # user (dev) apps
+      manifest.json
+      templates/<app_name>/index_partial.html
+      static/<app_name>/...
+    projects/<slug>/                # published projects
+      manifest.json
+      ...
+```
+
+## Base Directory
+
+```python
+def get_base_dir(base_dir: Union[str, Path, None] = None) -> Path
+```
+
+Priority: explicit argument > `SCITEX_BASE_DIR` env var.
+
+```python
+from scitex_app.paths import get_base_dir
+
+base = get_base_dir("/data/scitex")           # explicit
+base = get_base_dir()                          # reads SCITEX_BASE_DIR
+# raises ValueError if neither is available
+```
+
+## Project Directory Resolution
+
+```python
+def resolve_user_project_dir(
+    owner: str,
+    repo: str,
+    *,
+    base_dir: Union[str, Path, None] = None,
+) -> Optional[Path]
+```
+
+Returns `None` if `base_dir/data/users/<owner>/proj/<repo>/` does not exist.
+
+```python
+from scitex_app.paths import resolve_user_project_dir
+
+project_dir = resolve_user_project_dir("alice", "my_app")
+if project_dir:
+    print(project_dir)  # Path(".../data/users/alice/proj/my_app")
+```
+
+```python
+def resolve_published_project_dir(
+    slug: str,
+    *,
+    base_dir: Union[str, Path, None] = None,
+) -> Optional[Path]
+```
+
+Returns `None` if `base_dir/data/projects/<slug>/` does not exist.
+
+```python
+from scitex_app.paths import resolve_published_project_dir
+
+project_dir = resolve_published_project_dir("my-app-v2")
+```
+
+## Manifest
+
+```python
+def resolve_manifest(project_dir: Union[str, Path]) -> dict
+```
+
+Reads `manifest.json` from a project directory. Returns `{}` if the file does not exist or is invalid JSON (logs a warning).
+
+```python
+from scitex_app.paths import resolve_manifest
+
+manifest = resolve_manifest(project_dir)
+app_name = manifest.get("name", "unknown")
+```
+
+## Template Resolution
+
+```python
+def find_partial_template(
+    templates_dir: Union[str, Path],
+    filename: str = "index_partial.html",
+) -> Optional[Path]
+```
+
+Supports two layouts:
+- Flat: `templates/index_partial.html`
+- Nested: `templates/<app_name>/index_partial.html` (first matching subdirectory)
+
+```python
+def resolve_template_dir(project_dir: Union[str, Path]) -> Optional[Path]
+```
+
+Returns `project_dir/templates` if it exists, else `None`.
+
+## Static Directory
+
+```python
+def resolve_static_dir(project_dir: Union[str, Path]) -> Optional[Path]
+```
+
+Returns `project_dir/static` if it exists, else `None`.
+
+## Module Name Parsing
+
+```python
+def parse_dev_module_name(module_name: str) -> Optional[tuple[str, str]]
+```
+
+Parses the `dev__<owner>__<repo>` convention used by scitex-cloud for dev apps.
+
+```python
+from scitex_app.paths import parse_dev_module_name
+
+result = parse_dev_module_name("dev__alice__my_app")
+# ("alice", "my_app")
+
+result = parse_dev_module_name("published_app")
+# None — not a dev module name
+```
+
+## Directory Utilities
+
+```python
+def safe_iterdir(directory: Union[str, Path]) -> Iterator[Path]
+```
+
+Iterates directory entries in sorted order, skipping hidden files (names starting with `.`). Silently handles `PermissionError` and `OSError`.
+
+```python
+def validate_project_structure(project_dir: Union[str, Path]) -> tuple[bool, str]
+```
+
+Returns `(is_valid, message)`. Checks:
+1. `project_dir` exists and is a directory
+2. `project_dir/templates/` exists
+3. `index_partial.html` is found inside `templates/`
+
+```python
+from scitex_app.paths import validate_project_structure
+
+ok, msg = validate_project_structure("/path/to/my_app")
+if not ok:
+    print(f"Invalid: {msg}")
+```

--- a/src/scitex_app/_skills/scitex-app/standalone.md
+++ b/src/scitex_app/_skills/scitex-app/standalone.md
@@ -1,0 +1,85 @@
+---
+name: standalone
+description: run_standalone() — launch a SciTeX app locally with the full workspace shell (Django + sidebar + file tree + AI panel) without scitex-cloud.
+---
+
+# Standalone Mode
+
+`scitex_app._standalone.run_standalone()` launches any SciTeX app locally with the full workspace shell — same UX as scitex-cloud, no server required.
+
+## run_standalone()
+
+```python
+def run_standalone(
+    app_module: str,
+    port: int = 8050,
+    host: str = "127.0.0.1",
+    open_browser: bool = True,
+    hot_reload: bool = False,
+    working_dir: Optional[str] = None,
+    desktop: bool = False,
+    extra_installed_apps: Optional[list[str]] = None,
+    extra_staticfiles_dirs: Optional[list[str]] = None,
+    extra_env: Optional[dict[str, str]] = None,
+) -> None
+```
+
+### Parameters
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `app_module` | required | Dotted path to the app's Django module (e.g. `"my_app"`) |
+| `port` | `8050` | TCP port for the Django server |
+| `host` | `"127.0.0.1"` | Host to bind (use `"0.0.0.0"` for LAN access) |
+| `open_browser` | `True` | Open browser tab automatically after 1.5 s |
+| `hot_reload` | `False` | Enable Django `--reload` (file watching) |
+| `working_dir` | `None` | Sets `SCITEX_WORKING_DIR`; defaults to `cwd` |
+| `desktop` | `False` | Launch as native window via `pywebview` if installed |
+| `extra_installed_apps` | `None` | Additional Django app strings to add to `INSTALLED_APPS` |
+| `extra_staticfiles_dirs` | `None` | Additional static file directories |
+| `extra_env` | `None` | Extra env vars to set before Django configures |
+
+### Basic usage
+
+```python
+from scitex_app._standalone import run_standalone
+
+# Minimal — app at my_app/urls.py, my_app/views.py, etc.
+run_standalone(app_module="my_app")
+
+# Custom port, no browser
+run_standalone(app_module="my_app", port=5050, open_browser=False)
+
+# Native desktop window (requires: pip install pywebview)
+run_standalone(app_module="my_app", desktop=True)
+```
+
+### From a scaffolded app's CLI
+
+Apps created with `scitex-app app init` get a `_cli.py` with a `gui` command:
+
+```bash
+my-app gui                           # default port 8050
+my-app gui --port 5000 --no-browser
+my-app gui --force                   # kill existing process on port first
+```
+
+### Django settings configured
+
+`run_standalone()` calls `django.conf.settings.configure()` with:
+
+- `INSTALLED_APPS`: `django.contrib.staticfiles`, `<app_module>`, `scitex_ui` (if installed)
+- `ROOT_URLCONF`: `<app_module>.urls`
+- `STATIC_URL`: `/static/`
+- `STATICFILES_DIRS`: app's own `static/` + `_standalone_static/` shell assets
+- `DATABASES`: `{}` (no DB required for read-only apps)
+- `SECRET_KEY`: from `DJANGO_SECRET_KEY` env or `"scitex-standalone-dev-key"`
+- `DEBUG`: from `DJANGO_DEBUG` env (default `"true"`)
+
+Settings configure only once — calling `run_standalone()` a second time is a no-op if Django is already configured.
+
+### Requirements
+
+- `django` (always required)
+- `scitex_ui` (optional, provides the workspace shell sidebar/panel)
+- `pywebview` (optional, only for `desktop=True`)


### PR DESCRIPTION
## Summary
- Add `_skills/<pkg>/` directory with non-monolith skills layout
- SKILL.md is index-only with links to focused sub-skill files
- Each sub-skill verified against actual source code
- pyproject.toml force-include for wheel bundling

## Test plan
- [ ] CI passes
- [ ] Skills files included in wheel

Generated with [Claude Code](https://claude.com/claude-code)