### PR TITLE
fix(skills): resolve default install path under ~/.scitex/app/runtime/skills/

### DIFF
--- a/src/scitex_app/_cli/_skills.py
+++ b/src/scitex_app/_cli/_skills.py
@@ -7,15 +7,77 @@ Self-contained. No scitex-dev runtime dep — walks the package's own
 from __future__ import annotations
 
 import os as _os
+import shutil as _shutil
 from pathlib import Path
 
 import click
 
 PKG = "scitex-app"
+_PKG_SHORT = "app"  # scitex-app → app (prefix-stripping rule)
+
+
+# ---------------------------------------------------------------------------
+# Path resolution — always via helper, never hardcoded
+# ---------------------------------------------------------------------------
+
+
+def _scitex_dir() -> Path:
+    """Return the ecosystem-wide user-scope root.
+
+    Respects ``$SCITEX_DIR`` for relocation (default ``~/.scitex``).
+    """
+    return Path(_os.environ.get("SCITEX_DIR", Path.home() / ".scitex"))
+
+
+def _default_skills_base() -> Path:
+    """Resolve the default parent directory for skills installation.
+
+    Returns ``<SCITEX_DIR>/app/runtime/skills/`` — inside the package's
+    own namespace (``app``), under the runtime tree, so it honours
+    ``$SCITEX_DIR`` and the ecosystem state-directory conventions.
+    """
+    return _scitex_dir() / _PKG_SHORT / "runtime" / "skills"
+
+
+def _legacy_skills_dir() -> Path:
+    """Return the legacy cross-package skills path for back-compat."""
+    return _scitex_dir() / "dev" / "skills" / PKG
+
+
+def _migrate_legacy_skills(target: Path) -> None:
+    """Migrate skills from the legacy ``~/.scitex/dev/skills/scitex-app/`` path.
+
+    If the legacy directory exists, move its contents to *target* and
+    emit a one-time deprecation warning.  The legacy read-path is kept
+    for one minor version (per local-state-directives §8).
+    """
+    legacy = _legacy_skills_dir()
+    if not legacy.is_dir():
+        return
+    # target parent already exists (caller ensures it)
+    click.echo(
+        f"warning: migrating skills from {legacy} to {target} "
+        f"(legacy location deprecated — will be removed in a future release).",
+        err=True,
+    )
+    for child in legacy.iterdir():
+        dest = target / child.name
+        if not dest.exists():
+            _shutil.move(str(child), str(dest))
+    # remove the now-empty legacy directory
+    try:
+        legacy.rmdir()
+    except OSError:
+        pass  # not empty — skip, next install will finish migration
+
+
+# ---------------------------------------------------------------------------
+# Skill source (bundled in the wheel)
+# ---------------------------------------------------------------------------
 
 
 def _skills_root() -> Path:
-    """Resolve the bundled `_skills/scitex-app/` directory."""
+    """Resolve the bundled ``_skills/scitex-app/`` directory."""
     import scitex_app
 
     pkg_dir = Path(scitex_app.__file__).parent
@@ -23,10 +85,15 @@ def _skills_root() -> Path:
 
 
 def _list_skill_files(root: Path) -> list[Path]:
-    """All `.md` files under `_skills/scitex-app/` (recursive), excluding SKILL.md."""
+    """All ``.md`` files under ``_skills/scitex-app/`` (recursive), excluding SKILL.md."""
     if not root.is_dir():
         return []
     return sorted(p for p in root.rglob("*.md") if p.is_file() and p.name != "SKILL.md")
+
+
+# ---------------------------------------------------------------------------
+# CLI commands
+# ---------------------------------------------------------------------------
 
 
 @click.group(name="skills", invoke_without_command=True)
@@ -38,8 +105,8 @@ def skills_group(ctx) -> None:
     Examples:
       $ scitex-app skills list
       $ scitex-app skills get 01_installation
-      $ scitex-app skills install                  # → ~/.scitex/dev/skills/scitex-app/
-      $ scitex-app skills install --claude-symlink # also expose to ~/.claude/skills/scitex/
+      $ scitex-app skills install                # → ~/.scitex/app/runtime/skills/scitex-app/
+      $ scitex-app skills install --claude-symlink
     """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
@@ -79,7 +146,7 @@ def skills_list(as_json: bool) -> None:
 @click.argument("name")
 @click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON.")
 def skills_get(name: str, as_json: bool) -> None:
-    """Print the contents of a skill file by NAME (e.g. `01_installation`).
+    """Print the contents of a skill file by NAME (e.g. ``01_installation``).
 
     \b
     Example:
@@ -116,7 +183,9 @@ def skills_get(name: str, as_json: bool) -> None:
     "--dest",
     type=click.Path(),
     default=None,
-    help="Destination dir (default: ~/.scitex/dev/skills/scitex-app/).",
+    help=(
+        "Destination parent dir (default: ~/.scitex/app/runtime/skills/scitex-app/)."
+    ),
 )
 @click.option(
     "--no-link",
@@ -141,9 +210,10 @@ def skills_install(
     """Install this package's skills into a target directory.
 
     \b
-    Default: symlink the entire `_skills/scitex-app/` dir to
-    ~/.scitex/dev/skills/scitex-app/ so add/rename/delete in
-    source propagates immediately.
+    Default: symlink the entire ``_skills/scitex-app/`` dir to
+    ``~/.scitex/app/runtime/skills/scitex-app/`` so add/rename/delete
+    in source propagates immediately.  Respects ``$SCITEX_DIR`` for
+    ecosystem-wide relocation.
 
     \b
     Example:
@@ -157,46 +227,45 @@ def skills_install(
         click.echo(f"no skills directory at {src}", err=True)
         raise SystemExit(1)
 
-    base = (
-        Path(dest).expanduser() if dest else Path.home() / ".scitex" / "dev" / "skills"
-    )
+    base = Path(dest).expanduser() if dest else _default_skills_base()
     target = base / PKG
 
     if dry_run:
         action = "copy" if no_link else "symlink"
-        click.echo(f"would {action} {src} → {target}")
+        click.echo(f"would {action} {src} -> {target}")
         if claude_symlink:
-            link = Path.home() / ".claude" / "skills" / "scitex"
-            click.echo(f"would symlink {link} → {base}")
+            claude_link = Path.home() / ".claude" / "skills" / "scitex"
+            click.echo(f"would symlink {claude_link} -> {base}")
         return
 
     base.mkdir(parents=True, exist_ok=True)
+
+    # Back-compat: migrate from legacy ~/.scitex/dev/skills/scitex-app/
+    if dest is None:
+        _migrate_legacy_skills(target.parent)
+
     if target.is_symlink() or target.is_file():
         target.unlink()
     elif target.is_dir():
-        import shutil as _shutil
-
         _shutil.rmtree(target)
 
     if no_link:
-        import shutil as _shutil
-
         _shutil.copytree(src, target)
-        click.echo(f"copied {src} → {target}")
+        click.echo(f"copied {src} -> {target}")
     else:
         _os.symlink(src, target, target_is_directory=True)
-        click.echo(f"linked {target} → {src}")
+        click.echo(f"linked {target} -> {src}")
 
     if claude_symlink:
-        link = Path.home() / ".claude" / "skills" / "scitex"
-        link.parent.mkdir(parents=True, exist_ok=True)
-        if link.is_symlink():
-            link.unlink()
-        if not link.exists():
-            _os.symlink(base.resolve(), link, target_is_directory=True)
-            click.echo(f"linked {link} → {base}")
+        claude_link = Path.home() / ".claude" / "skills" / "scitex"
+        claude_link.parent.mkdir(parents=True, exist_ok=True)
+        if claude_link.is_symlink():
+            claude_link.unlink()
+        if not claude_link.exists():
+            _os.symlink(base.resolve(), claude_link, target_is_directory=True)
+            click.echo(f"linked {claude_link} -> {base}")
         else:
             click.echo(
-                f"warning: {link} exists and is not a symlink — skipping",
+                f"warning: {claude_link} exists and is not a symlink - skipping",
                 err=True,
             )


### PR DESCRIPTION
## Summary

- Fixes a local-state-directory violation: `scitex-app skills install` wrote into
  `~/.scitex/dev/skills/scitex-app/` (the `scitex-dev` namespace) instead of the
  package's own prefix-stripped root (`app/`).
- Regenerable content (skills) now resolves under `<pkg-short>/runtime/` per
  ecosystem rule §4b.
- `$SCITEX_DIR` relocation is honoured; legacy `~/.scitex/dev/skills/scitex-app/`
  is migrated on first install with a deprecation warning (per §8 back-compat).

## Changes

1. **`src/scitex_app/_cli/_skills.py`** — replaces hardcoded `Path.home() / ".scitex" / "dev" / "skills"`
   with `_default_skills_base()` → `<SCITEX_DIR>/app/runtime/skills/`. Adds
   `_migrate_legacy_skills()` for one-version back-compat.

## Test plan

- [x] Path resolution verified: `assert "/runtime/" in str(resolved)`
- [x] `$SCITEX_DIR` relocation verified
- [x] Legacy path resolved correctly: `~/.scitex/dev/skills/scitex-app`
- [ ] CI: pytest (3.11/3.12/3.13) and sphinx