### PR TITLE
docs(refresh): sync CLI reference, env vars, and install-dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ scitex-app app init . --name my_cool_app
 scitex-app app validate .
 
 # Dev-install on your SciTeX Cloud server
-scitex-app app dev-install . --server http://127.0.0.1:8000
+scitex-app app install-dev . --server http://127.0.0.1:8000
 
 # Submit for public review
 scitex-app app submit .

--- a/docs/sphinx/app_development.rst
+++ b/docs/sphinx/app_development.rst
@@ -3,7 +3,7 @@ App Development Guide
 
 SciTeX apps are self-contained Django plugins that integrate into the
 SciTeX Cloud workspace. This guide covers the full lifecycle: scaffold,
-validate, dev-install, and submit.
+validate, install-dev, and submit.
 
 .. contents:: Contents
    :local:
@@ -186,10 +186,10 @@ SciTeX Cloud server for development testing:
    export SCITEX_API_TOKEN="your-jwt-token"
    export SCITEX_SERVER_URL="http://127.0.0.1:8000"
 
-   scitex-app app dev-install .
+   scitex-app app install-dev .
 
    # Or pass options explicitly
-   scitex-app app dev-install . \
+   scitex-app app install-dev . \
        --server http://my-server:8000 \
        --token  "$SCITEX_API_TOKEN"
 
@@ -355,9 +355,9 @@ Typical Workflow
 
    # 4. Dev-install on a running server for live testing
    export SCITEX_API_TOKEN="..."
-   scitex-app app dev-install . --server http://127.0.0.1:8000
+   scitex-app app install-dev . --server http://127.0.0.1:8000
 
-   # 5. Iterate: edit → validate → dev-install
+   # 5. Iterate: edit → validate → install-dev
    # (The server hot-reloads on file changes)
 
    # 6. Submit when ready

--- a/docs/sphinx/cli.rst
+++ b/docs/sphinx/cli.rst
@@ -89,9 +89,13 @@ File Commands
 
 .. code-block:: bash
 
-   scitex-app read <path> [--root DIR] [--binary]
-   scitex-app list [DIR] [--root DIR] [--ext .yaml]
-   scitex-app exists <path> [--root DIR]
+   scitex-app file read <path> [--root DIR] [--binary]
+   scitex-app file write <path> <content> [--root DIR]
+   scitex-app file list [DIR] [--root DIR] [--ext .yaml]
+   scitex-app file exists <path> [--root DIR]
+   scitex-app file delete <path> [--root DIR]
+   scitex-app file rename <old> <new> [--root DIR]
+   scitex-app file copy <src> <dest> [--root DIR]
 
 
 Integration

--- a/src/scitex_app/_skills/scitex-app/04_cli-reference.md
+++ b/src/scitex_app/_skills/scitex-app/04_cli-reference.md
@@ -51,8 +51,8 @@ scitex-app app submit <DIR> --target prod    # ship to a SciTeX Cloud target
 | `file`  | Read / write / list files via the registered Files SDK backend   |
 
 ```bash
-scitex-app file put results/today.csv data.csv
-scitex-app file get results/today.csv ./local.csv
+scitex-app file read results/today.csv
+scitex-app file write results/today.csv "content"
 scitex-app file list results/
 ```
 

--- a/src/scitex_app/_skills/scitex-app/06_environment-vars.md
+++ b/src/scitex_app/_skills/scitex-app/06_environment-vars.md
@@ -11,6 +11,7 @@ tags: [scitex-app-environment-vars]
 
 | Variable | Purpose | Used by |
 |----------|---------|---------|
+| `SCITEX_DIR` | Relocate the user-scope `.scitex/` tree | `scitex_app._cli._skills._scitex_dir()` |
 | `SCITEX_BASE_DIR` | Base directory for app path resolution | `scitex_app.paths.get_base_dir()` |
 | `SCITEX_WORKING_DIR` | Working directory for standalone file tree | `run_standalone()` |
 

--- a/src/scitex_app/_skills/scitex-app/32_cli.md
+++ b/src/scitex_app/_skills/scitex-app/32_cli.md
@@ -63,13 +63,13 @@ scitex-app app validate .
 scitex-app app validate /path/to/my_app
 ```
 
-### app dev-install
+### app install-dev
 
 ```bash
-scitex-app app dev-install [APP_DIR] [OPTIONS]
+scitex-app app install-dev [APP_DIR] [OPTIONS]
 ```
 
-Validate locally, then call the SciTeX Cloud dev-install API. App appears in workspace sidebar immediately.
+Validate locally, then call the SciTeX Cloud install-dev API. App appears in workspace sidebar immediately.
 
 | Option | Default | Env var | Purpose |
 |--------|---------|---------|---------|
@@ -79,8 +79,8 @@ Validate locally, then call the SciTeX Cloud dev-install API. App appears in wor
 | `--repo`, `-r` | from manifest | — | Gitea repo name |
 
 ```bash
-scitex-app app dev-install .
-scitex-app app dev-install . --server http://my-server:8000
+scitex-app app install-dev .
+scitex-app app install-dev . --server http://my-server:8000
 ```
 
 ### app submit
@@ -103,40 +103,40 @@ scitex-app app submit /path/to/my_app --server https://scitex.example.com
 
 ## File Operations
 
-All file commands accept `--root` (default `.`) and `--json` for machine-readable output.
+All file commands are under the `file` subgroup and accept `--root` (default `.`) and `--json` for machine-readable output.
 
 ```bash
-scitex-app read <path> [--root DIR] [--binary] [--json]
-scitex-app write <path> [CONTENT] [--root DIR] [--stdin] [--json] [--dry-run]
-scitex-app list [DIRECTORY] [--root DIR] [--ext EXT]... [--json]
-scitex-app exists <path> [--root DIR] [--json]
-scitex-app delete <path> [--root DIR] [--json] [--dry-run]
-scitex-app rename <old-path> <new-path> [--root DIR] [--json] [--dry-run]
-scitex-app copy <src-path> <dest-path> [--root DIR] [--json] [--dry-run]
+scitex-app file read <path> [--root DIR] [--binary] [--json]
+scitex-app file write <path> [CONTENT] [--root DIR] [--stdin] [--json] [--dry-run]
+scitex-app file list [DIRECTORY] [--root DIR] [--ext EXT]... [--json]
+scitex-app file exists <path> [--root DIR] [--json]
+scitex-app file delete <path> [--root DIR] [--json] [--dry-run]
+scitex-app file rename <old-path> <new-path> [--root DIR] [--json] [--dry-run]
+scitex-app file copy <src-path> <dest-path> [--root DIR] [--json] [--dry-run]
 ```
 
 ```bash
 # Read a file
-scitex-app read config.yaml
-scitex-app read data.bin --binary
+scitex-app file read config.yaml
+scitex-app file read data.bin --binary
 
 # Write content
-scitex-app write output.txt "hello world"
-echo "data" | scitex-app write output.txt --stdin
-scitex-app write output.txt "test" --dry-run
+scitex-app file write output.txt "hello world"
+echo "data" | scitex-app file write output.txt --stdin
+scitex-app file write output.txt "test" --dry-run
 
 # List files
-scitex-app list
-scitex-app list data --ext .yaml --ext .json
-scitex-app list --json
+scitex-app file list
+scitex-app file list data --ext .yaml --ext .json
+scitex-app file list --json
 
 # Check existence (exit code 0=exists, 1=missing)
-scitex-app exists config.yaml
+scitex-app file exists config.yaml
 
 # Delete, rename, copy with dry-run preview
-scitex-app delete temp.txt --dry-run
-scitex-app rename old.txt new.txt
-scitex-app copy src.txt dst.txt --dry-run
+scitex-app file delete temp.txt --dry-run
+scitex-app file rename old.txt new.txt
+scitex-app file copy src.txt dst.txt --dry-run
 ```
 
 ## Integration


### PR DESCRIPTION
## Summary

Periodic docs refresh to align with the current codebase. Fixes stale
command names, wrong subcommand structure, and missing env vars.

## Changes

| File | What changed |
|------|-------------|
| `README.md` | `dev-install` → `install-dev` |
| `docs/sphinx/cli.rst` | Deprecated top-level commands → current `file <verb>` subcommands |
| `docs/sphinx/app_development.rst` | `dev-install` → `install-dev` throughout |
| `_skills/scitex-app/04_cli-reference.md` | `file put`/`file get` → `file read`/`file write` |
| `_skills/scitex-app/06_environment-vars.md` | Added `SCITEX_DIR` env var |
| `_skills/scitex-app/32_cli.md` | Top-level read/write → `file <verb>` subcommands; `dev-install` → `install-dev` |

## Test plan

- [x] CI will verify: pytest matrix, sphinx build, import smoke