### PR TITLE
refactor(rename): scitex-cloud -> scitex-hub for platform refs (17 files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 ### Source: /home/ywatanabe/.git-templates/.gitignore-templates/Custom/Specific.gitignore ###
 # Please add files here
 # Sphinx local build dir (transient). The in-wheel bundle
-# src/<pkg>/_sphinx_html/ is intentionally tracked — scitex-cloud serves
+# src/<pkg>/_sphinx_html/ is intentionally tracked — scitex-hub serves
 # docs from it (general/04_docs_02_sphinx: do NOT gitignore _sphinx_html).
 docs/sphinx/_build/
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ scitex (orchestrator, core compute, CLI, MCP)
 **What this package does NOT own:**
 
 - Frontend components -- see [scitex-ui](https://github.com/ywatanabe1989/scitex-ui)
-- Platform server APIs -- see [scitex-cloud](https://github.com/ywatanabe1989/scitex-cloud)
+- Platform server APIs -- see [scitex-hub](https://github.com/ywatanabe1989/scitex-hub)
 - Core compute (io, stats, plt) -- see [scitex](https://github.com/ywatanabe1989/scitex-python)
 
 ## Part of SciTeX

--- a/docs/APP_SDK.md
+++ b/docs/APP_SDK.md
@@ -136,7 +136,7 @@ Apps register with pip entry points for automatic discovery:
 my_app = "my_app:scitex_module_config"
 ```
 
-The entry point must return a `ModuleConfig` instance. scitex-cloud's `discover_external_modules()` calls `entry_points(group="scitex_modules")` at startup.
+The entry point must return a `ModuleConfig` instance. scitex-hub's `discover_external_modules()` calls `entry_points(group="scitex_modules")` at startup.
 
 ## Cloud SDK Services
 
@@ -166,7 +166,7 @@ def my_chat_view(request):
 
 ## App Validation Pipeline
 
-The platform validates apps before approval using checks in both scitex-app (path/structure) and scitex-cloud (security):
+The platform validates apps before approval using checks in both scitex-app (path/structure) and scitex-hub (security):
 
 1. **Structure** -- `validate_project_structure()` checks for `templates/` and `index_partial.html`
 2. **Manifest** -- `resolve_manifest()` parses and validates `manifest.json`
@@ -185,6 +185,6 @@ The platform validates apps before approval using checks in both scitex-app (pat
 
 ## Cross-References
 
-- **scitex-cloud** (`docs/ARCHITECTURE/APP_PLATFORM.md`) -- Platform mounting, manifest loading, `ModuleConfig` registry
+- **scitex-hub** (`docs/ARCHITECTURE/APP_PLATFORM.md`) -- Platform mounting, manifest loading, `ModuleConfig` registry
 - **scitex-ui** (`docs/APP_SANDBOX.md`) -- Frontend CSS isolation, shared components, theme contract
 - **figrecipe** (`docs/SCITEX_APP_INTEGRATION.md`) -- Reference implementation using `FilesBackend` and `_django` convention

--- a/docs/sphinx/app_development.rst
+++ b/docs/sphinx/app_development.rst
@@ -15,11 +15,11 @@ Role of Each Package
 .. code-block:: text
 
    scitex-app  (this package) — developer SDK: scaffold, validate, install
-   scitex-cloud               — platform: mounts apps, handles security, routing
+   scitex-hub                 — platform: mounts apps, handles security, routing
    figrecipe                  — reference app: see how a real app is built
 
 ``scitex-app`` is the **only** package app developers need to install.
-``scitex-cloud`` is the platform; developers interact with it only through
+``scitex-hub`` is the platform; developers interact with it only through
 the server URL and API token.
 
 

--- a/src/scitex_app/_skills/scitex-app/01_installation.md
+++ b/src/scitex_app/_skills/scitex-app/01_installation.md
@@ -47,11 +47,11 @@ Expected: a version string, the CLI help, then a scaffolded app at
 
 ## Cloud companion (optional)
 
-To **dev-install** an app into a running SciTeX Cloud workspace, also
+To **dev-install** an app into a running SciTeX Hub workspace, also
 install:
 
 ```bash
-pip install scitex-cloud         # provides the workspace endpoint
+pip install scitex-hub           # provides the workspace endpoint
 ```
 
 Used as:

--- a/src/scitex_app/_skills/scitex-app/05_standalone.md
+++ b/src/scitex_app/_skills/scitex-app/05_standalone.md
@@ -1,13 +1,13 @@
 ---
 description: |
   [TOPIC] Standalone Mode
-  [DETAILS] run_standalone() — launch a SciTeX app locally with the full workspace shell (Django + sidebar + file tree + AI panel) without scitex-cloud..
+  [DETAILS] run_standalone() — launch a SciTeX app locally with the full workspace shell (Django + sidebar + file tree + AI panel) without scitex-hub..
 tags: [scitex-app-standalone]
 ---
 
 # Standalone Mode
 
-`scitex_app._standalone.run_standalone()` launches any SciTeX app locally with the full workspace shell — same UX as scitex-cloud, no server required.
+`scitex_app._standalone.run_standalone()` launches any SciTeX app locally with the full workspace shell — same UX as scitex-hub, no server required.
 
 ## run_standalone()
 

--- a/src/scitex_app/_skills/scitex-app/07_backend-validation.md
+++ b/src/scitex_app/_skills/scitex-app/07_backend-validation.md
@@ -62,6 +62,6 @@ myapp/
 - `_django/views.py` and `_django/urls.py` required for platform integration
 - Use `get_files()` for all file I/O — never `open()` directly in app logic
 - **Packaging**: Apps with a `bridge` key in manifest.json must keep
-  `_django/frontend/src/` in their source tree. scitex-cloud discovers
+  `_django/frontend/src/` in their source tree. scitex-hub discovers
   bridges by scanning sibling directories. Use an `[app]` optional extra
   for platform Python deps. In CI, clone the repo as a sibling.

--- a/src/scitex_app/_skills/scitex-app/16_app-registration-internals.md
+++ b/src/scitex_app/_skills/scitex-app/16_app-registration-internals.md
@@ -81,10 +81,10 @@ only.
 
 | File | Role |
 |------|------|
-| `scitex-cloud/apps/infra/workspace_app/registry.py` | `ModuleConfig` dataclass, `register_module()`, `get_all_modules()` |
-| `scitex-cloud/apps/workspace/apps_app/services/app_loader.py` | `load_approved_apps()` — published app registration at startup |
-| `scitex-cloud/apps/workspace/apps_app/services/dev_app_loader.py` | `build_module_config()` — per-request dev app config synthesis |
-| `scitex-cloud/apps/infra/workspace_app/context_processors.py` | Injects `workspace_modules` into template context |
+| `scitex-hub/apps/infra/workspace_app/registry.py` | `ModuleConfig` dataclass, `register_module()`, `get_all_modules()` |
+| `scitex-hub/apps/workspace/apps_app/services/app_loader.py` | `load_approved_apps()` — published app registration at startup |
+| `scitex-hub/apps/workspace/apps_app/services/dev_app_loader.py` | `build_module_config()` — per-request dev app config synthesis |
+| `scitex-hub/apps/infra/workspace_app/context_processors.py` | Injects `workspace_modules` into template context |
 
 ## Troubleshooting Registration
 

--- a/src/scitex_app/_skills/scitex-app/31_paths.md
+++ b/src/scitex_app/_skills/scitex-app/31_paths.md
@@ -126,7 +126,7 @@ Returns `project_dir/static` if it exists, else `None`.
 def parse_dev_module_name(module_name: str) -> Optional[tuple[str, str]]
 ```
 
-Parses the `dev__<owner>__<repo>` convention used by scitex-cloud for dev apps.
+Parses the `dev__<owner>__<repo>` convention used by scitex-hub for dev apps.
 
 ```python
 from scitex_app.paths import parse_dev_module_name

--- a/src/scitex_app/_standalone.py
+++ b/src/scitex_app/_standalone.py
@@ -3,7 +3,7 @@
 Provides a minimal Django server with the full workspace shell
 (sidebar, three-column layout, file tree, AI panel) from scitex-ui.
 
-Any app can use this to run locally with the same UX as scitex-cloud:
+Any app can use this to run locally with the same UX as scitex-hub:
 
     from scitex_app._standalone import run_standalone
     run_standalone(app_module="figrecipe._django", port=5050)

--- a/src/scitex_app/appmaker/_scaffold.py
+++ b/src/scitex_app/appmaker/_scaffold.py
@@ -254,9 +254,9 @@ def gui(port, host, no_browser, force):
 
 
 def _pyproject_toml(name, label, description, license_id):
-    """Generate pyproject.toml for dual-mode app (standalone + scitex-cloud extension)."""
+    """Generate pyproject.toml for dual-mode app (standalone + scitex-hub extension)."""
     slug = name.replace("_", "-")
-    desc = description or f"{label} — a SciTeX Cloud app."
+    desc = description or f"{label} — a SciTeX Hub app."
     return f"""[build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/scitex_app/appmaker/_scaffold_agent_context.py
+++ b/src/scitex_app/appmaker/_scaffold_agent_context.py
@@ -164,7 +164,7 @@ Each SciTeX package owns its own AI agent documentation. Read these for full API
 |---------|-------|----------------|
 | **scitex-ui** | `pip show scitex-ui` → docs/APP_DEVELOPER_GUIDE.md | React components (DataTable, FileBrowser), bridge contract, theme CSS, usePanelResize |
 | **scitex-app** | `pip show scitex-app` → docs/APP_DEVELOPER_GUIDE.md | FilesBackend SDK, ScitexAppConfig, manifest schema, AppValidator |
-| **scitex-cloud** | Platform docs/APP_DEVELOPER_GUIDE.md | Platform services (DataStore, FileVault, JobQueue), dev install, workspace integration |
+| **scitex-hub** | Platform docs/APP_DEVELOPER_GUIDE.md | Platform services (DataStore, FileVault, JobQueue), dev install, workspace integration |
 
 ### Reference Implementation
 

--- a/src/scitex_app/appmaker/_scaffold_docs.py
+++ b/src/scitex_app/appmaker/_scaffold_docs.py
@@ -70,13 +70,13 @@ Virtual indexed columns are created automatically — no Django migrations neede
 
 ---
 
-## Python SDK (`scitex_cloud.sdk`)
+## Python SDK (`scitex_hub.sdk`)
 
 Instead of constructing raw HTTP requests, use the Python SDK from your
 context builder or any backend code running inside Apptainer:
 
 ```python
-from scitex_cloud.sdk import data, files, jobs
+from scitex_hub.sdk import data, files, jobs
 
 # DataStore — CRUD
 data.create("{name}", "Sample", {{"name": "Test", "condition": "A"}})
@@ -102,9 +102,9 @@ Auth is automatic via `SCITEX_API_TOKEN` env var (injected into Apptainer).
 
 **CLI equivalent:**
 ```bash
-scitex-cloud sdk data list {name} Sample
-scitex-cloud sdk files upload {name} local.csv exports/data.csv
-scitex-cloud sdk jobs submit {name} export_csv --params '{{"format":"xlsx"}}'
+scitex-hub sdk data list {name} Sample
+scitex-hub sdk files upload {name} local.csv exports/data.csv
+scitex-hub sdk jobs submit {name} export_csv --params '{{"format":"xlsx"}}'
 ```
 
 ---
@@ -115,7 +115,7 @@ Bootstrap your app with one call — returns user profile, project metadata,
 and file tree:
 
 ```python
-from scitex_cloud.sdk._client import get_client
+from scitex_hub.sdk._client import get_client
 result = get_client().request("GET", "/platform/api/context/", params={{"project_id": pid}})
 # result["context"]["user"]     -> {{"id": ..., "username": ..., "email": ...}}
 # result["context"]["project"]  -> {{"id": ..., "name": ..., "slug": ...}}
@@ -324,10 +324,10 @@ This validates:
 
 Apps follow a two-tier distribution model:
 
-1. **Scaffold:** `scitex-cloud app init .` — creates all boilerplate
+1. **Scaffold:** `scitex-hub app init .` — creates all boilerplate
 2. **Develop:** Edit templates, views, and CSS in your project
-3. **Validate:** `scitex-cloud app validate .` — checks structure and security
-4. **Submit:** `scitex-cloud app submit .` — opens a PR on `scitex/apps` registry
+3. **Validate:** `scitex-hub app validate .` — checks structure and security
+4. **Submit:** `scitex-hub app submit .` — opens a PR on `scitex/apps` registry
 5. **Review:** Staff reviews the PR and merges to approve
 6. **Live:** Merged apps appear in the public Apps catalog
 

--- a/src/scitex_app/appmaker/_scaffold_html.py
+++ b/src/scitex_app/appmaker/_scaffold_html.py
@@ -450,7 +450,7 @@ To test your app in the SciTeX workspace, use **Dev Install**:
 
 Alternatively, from the CLI:
 ```bash
-scitex-cloud app dev .
+scitex-hub app dev .
 ```
 
 Note: Dev Install is the standard path for external apps. Do NOT edit
@@ -460,7 +460,7 @@ Note: Dev Install is the standard path for external apps. Do NOT edit
 
 When ready to publish:
 
-1. Run validation: `scitex-cloud app validate .`
+1. Run validation: `scitex-hub app validate .`
 2. Submit: use the Apps settings panel in your project
 
 ## License

--- a/src/scitex_app/sdk/__init__.py
+++ b/src/scitex_app/sdk/__init__.py
@@ -109,7 +109,7 @@ __all__ = [
 
 
 # Internal cloud modules — accessible via scitex_app.sdk._client etc.
-# but NOT part of the public API contract. Use scitex_cloud.sdk for
+# but NOT part of the public API contract. Use scitex_hub.sdk for
 # cloud service access (data, files, jobs, scitex, external).
 def __getattr__(name: str) -> Any:
     """Lazy-load cloud internals on demand (not in __all__)."""

--- a/src/scitex_app/sdk/_protocol.py
+++ b/src/scitex_app/sdk/_protocol.py
@@ -20,7 +20,7 @@ class FilesBackend(Protocol):
     Implementations
     ---------------
     - ``FileSystemBackend`` — local pathlib (ships with scitex-app)
-    - ``CloudFilesBackend`` — HTTP via scitex_cloud (provided at runtime)
+    - ``CloudFilesBackend`` — HTTP via scitex_hub (provided at runtime)
     """
 
     def read(self, path: str, *, binary: bool = False) -> Union[str, bytes]:

--- a/src/scitex_app/validator.py
+++ b/src/scitex_app/validator.py
@@ -168,7 +168,7 @@ class AppValidator:
             else:
                 self._result.add_warning(
                     "No _django/ directory found. "
-                    "App may not integrate with scitex-cloud."
+                    "App may not integrate with scitex-hub."
                 )
                 return
 


### PR DESCRIPTION
## Summary

Follows the upstream rename in ywatanabe1989/scitex-hub (formerly `scitex-cloud`) per ADR-0001 + ADR-0003 in the platform repo. Updates current-behavior text, platform refs, CLI command examples, Python SDK import examples in scaffold-generated docs, and the GitHub URL.

### What's renamed (17 files / 35 line edits)

| file | what |
| --- | --- |
| `README.md` | GitHub URL → `ywatanabe1989/scitex-hub` |
| `.gitignore` | comment about platform serving `_sphinx_html` docs |
| `docs/APP_SDK.md` (×3) | platform refs (discoverer / validation pipeline / cross-ref) |
| `docs/sphinx/app_development.rst` (×2) | ecosystem diagram + "scitex-cloud is the platform" |
| `src/scitex_app/_standalone.py` | docstring "same UX as scitex-cloud" |
| `src/scitex_app/validator.py` | warning string "may not integrate with scitex-cloud" |
| `src/scitex_app/sdk/_protocol.py` | `CloudFilesBackend` docstring "HTTP via scitex_cloud" → `scitex_hub` |
| `src/scitex_app/sdk/__init__.py` | "Use scitex_cloud.sdk" comment → `scitex_hub.sdk` |
| `src/scitex_app/appmaker/_scaffold.py` | pyproject template description + dual-mode docstring |
| `src/scitex_app/appmaker/_scaffold_agent_context.py` | ecosystem table row |
| `src/scitex_app/appmaker/_scaffold_docs.py` (×9) | scaffold-generated SDK header, `from scitex_cloud.sdk import` examples, `scitex-cloud sdk/app` CLI examples → `scitex_hub.sdk` / `scitex-hub …` |
| `src/scitex_app/appmaker/_scaffold_html.py` (×2) | CLI example invocations |
| `src/scitex_app/_skills/scitex-app/01_installation.md` | `pip install scitex-cloud` → `pip install scitex-hub` + surrounding "SciTeX Cloud workspace" → "SciTeX Hub workspace" |
| `src/scitex_app/_skills/scitex-app/05_standalone.md` (×2) | platform refs |
| `src/scitex_app/_skills/scitex-app/07_backend-validation.md` | "scitex-cloud discovers bridges" current-behavior |
| `src/scitex_app/_skills/scitex-app/16_app-registration-internals.md` (×4) | file-path refs `scitex-cloud/apps/...` → `scitex-hub/apps/...` |
| `src/scitex_app/_skills/scitex-app/31_paths.md` | "convention used by scitex-cloud for dev apps" |

### What is intentionally KEPT

- `src/scitex_app/_chat/_models.py:5` and `_session_views.py:5` — "Ported from scitex-cloud's llm_app/views/sessions.py" provenance comments. The port happened when the source was named scitex-cloud; a future reader looking for `llm_app/` inside scitex-hub may find it restructured. Historical accuracy beats find-replace consistency here.

### Existing apps still work

Apps using `from scitex_cloud.sdk import ...` (legacy import path) continue to work via the deprecation shim documented in ADR-0001. This PR's `_scaffold_docs.py` update only affects NEWLY scaffolded apps — they get the canonical `scitex_hub.sdk` import path from the start.

### Test plan

- [ ] No code-behavior change — doc/comment/example-string text only. CI sanity check.
- [ ] `_scaffold_docs.py` is template-string Python — verify generated docs render correctly.
- [ ] `docs/sphinx/app_development.rst` rebuild renders correctly.

🤖 Authored by proj-scitex-hub on operator authorization. DRAFT pending review.