### PR TITLE
fix(appmaker): emit nested-package layout + add hatchling wheel block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,9 @@ packages = ["src/scitex_app"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "slow: marks tests as slow (pip-install/venv-build gates; deselect with '-m \"not slow\"')",
+]
 
 [tool.coverage.run]
 parallel = true

--- a/src/scitex_app/appmaker/_scaffold.py
+++ b/src/scitex_app/appmaker/_scaffold.py
@@ -111,65 +111,64 @@ def _build_all_files(
     *,
     frontend_type: str = "html",
 ):
-    """Build dict of relpath -> content for all scaffold files."""
+    """Build dict of relpath -> content for all scaffold files.
+
+    LAYOUT (nested-package fix, port of scitex-hub PR #293):
+
+    Wrapper-root files (build config + project metadata read directly
+    by tooling and by the operator):
+
+      <wrapper>/pyproject.toml
+      <wrapper>/README.md
+      <wrapper>/LICENSE
+      <wrapper>/AGENTS.md
+      <wrapper>/.gitignore
+
+    Python-package files (nested under ``<name>/`` so pip + hatchling
+    can build the wheel — the package directory MUST match the
+    normalized project name, otherwise ``hatchling.build`` errors with
+    "Unable to determine which files to ship inside the wheel"):
+
+      <wrapper>/<name>/__init__.py
+      <wrapper>/<name>/apps.py
+      <wrapper>/<name>/views.py
+      <wrapper>/<name>/urls.py
+      <wrapper>/<name>/tests.py
+      <wrapper>/<name>/skill.py
+      <wrapper>/<name>/_cli.py
+      <wrapper>/<name>/manifest.json
+      <wrapper>/<name>/templates/<name>/...
+      <wrapper>/<name>/static/<name>/...
+      <wrapper>/<name>/.agents/agents.json
+      <wrapper>/<name>/docs/PLATFORM.md
+
+    The hub's ``pip_install_user_app`` runs ``pip install --no-deps
+    --target=<install_dir> <gitea-archive-url>`` against this shape;
+    hatchling auto-detects ``<name>/`` as the package directory (via
+    the ``[tool.hatch.build.targets.wheel] packages = ["<name>"]``
+    declaration in the emitted pyproject) and lands the wheel cleanly
+    on ``sys.path``. ``<project.scripts> <slug> = "<name>._cli:main"``
+    also requires ``_cli.py`` to live INSIDE the package directory.
+    """
     use_react = frontend_type == "react"
     files = {}
 
-    # __init__.py
-    files["__init__.py"] = f'"""SciTeX Cloud App: {label}."""\n'
+    # -----------------------------------------------------------------
+    # Wrapper-root files (build system + project metadata)
+    # -----------------------------------------------------------------
 
-    # apps.py
-    files["apps.py"] = _apps_py(name, label, class_name)
-
-    # views.py
-    files["views.py"] = _views_py(name, label, description)
-
-    # urls.py
-    files["urls.py"] = _urls_py(name)
-
-    # tests.py
-    files["tests.py"] = _tests_py(name, label)
-
-    # skill.py
-    files["skill.py"] = _skill_py(name, label, description)
-
-    # manifest.json
-    files["manifest.json"] = _manifest_json(
-        name, label, icon, description, manifest, license_id, frontend_type
-    )
-
-    # Templates
-    files[f"templates/{name}/index.html"] = _index_html(
-        name, label, include_js_bundle=use_react
-    )
-    files[f"templates/{name}/index_partial.html"] = _index_partial_html(
-        name, label, icon, react_mount=use_react
-    )
-
-    # Static CSS
-    files[f"static/{name}/css/{name}.css"] = _app_css(name, label)
-
-    # Agents config
-    files[".agents/agents.json"] = _agents_json(name, label)
-    files["AGENTS.md"] = _agents_md(name, label, icon, description, frontend_type)
-
-    # Platform docs for agents
-    from ._scaffold_docs import _platform_docs_md
-
-    files["docs/PLATFORM.md"] = _platform_docs_md(name)
-
-    # README
+    files["pyproject.toml"] = _pyproject_toml(name, label, description, license_id)
     files["README.md"] = _readme_md(
         name, label, description, license_id, frontend_type=frontend_type
     )
 
-    # LICENSE
     license_text = generate_license_text(license_id)
     if license_text is None:
         license_text = generate_license_text("AGPL-3.0")
     files["LICENSE"] = license_text
 
-    # .gitignore
+    files["AGENTS.md"] = _agents_md(name, label, icon, description, frontend_type)
+
     files[".gitignore"] = "\n".join(
         [
             "# Runtime data (created by platform, not app source)",
@@ -199,15 +198,37 @@ def _build_all_files(
         ]
     )
 
-    # pyproject.toml for dual-mode (standalone + extension)
-    files["pyproject.toml"] = _pyproject_toml(name, label, description, license_id)
+    # -----------------------------------------------------------------
+    # Python-package files (nested under <name>/)
+    # -----------------------------------------------------------------
 
-    # CLI with gui command for standalone mode
-    files["_cli.py"] = _cli_py(name, label)
+    files[f"{name}/__init__.py"] = f'"""SciTeX Cloud App: {label}."""\n'
+    files[f"{name}/apps.py"] = _apps_py(name, label, class_name)
+    files[f"{name}/views.py"] = _views_py(name, label, description)
+    files[f"{name}/urls.py"] = _urls_py(name)
+    files[f"{name}/tests.py"] = _tests_py(name, label)
+    files[f"{name}/skill.py"] = _skill_py(name, label, description)
+    files[f"{name}/_cli.py"] = _cli_py(name, label)
+    files[f"{name}/manifest.json"] = _manifest_json(
+        name, label, icon, description, manifest, license_id, frontend_type
+    )
+    files[f"{name}/templates/{name}/index.html"] = _index_html(
+        name, label, include_js_bundle=use_react
+    )
+    files[f"{name}/templates/{name}/index_partial.html"] = _index_partial_html(
+        name, label, icon, react_mount=use_react
+    )
+    files[f"{name}/static/{name}/css/{name}.css"] = _app_css(name, label)
+    files[f"{name}/.agents/agents.json"] = _agents_json(name, label)
 
-    # React frontend files
+    from ._scaffold_docs import _platform_docs_md
+
+    files[f"{name}/docs/PLATFORM.md"] = _platform_docs_md(name)
+
+    # React frontend files (mount under the package directory too)
     if use_react:
-        files.update(build_react_files(name, label, icon))
+        for relpath, content in build_react_files(name, label, icon).items():
+            files[f"{name}/{relpath}"] = content
 
     return files
 
@@ -254,7 +275,15 @@ def gui(port, host, no_browser, force):
 
 
 def _pyproject_toml(name, label, description, license_id):
-    """Generate pyproject.toml for dual-mode app (standalone + scitex-cloud extension)."""
+    """Generate pyproject.toml for dual-mode app (standalone + scitex-cloud extension).
+
+    Includes ``[tool.hatch.build.targets.wheel] packages = ["<name>"]``
+    so the wheel build works against the nested-package layout that
+    ``_build_all_files`` emits — without this, hatchling errors
+    "Unable to determine which files to ship inside the wheel using
+    the following heuristics" and ``pip_install_user_app`` fails at
+    install time.
+    """
     slug = name.replace("_", "-")
     desc = description or f"{label} — a SciTeX Cloud app."
     return f"""[build-system]
@@ -277,6 +306,9 @@ dev = ["pytest>=7.0.0"]
 
 [project.entry-points."scitex_modules"]
 {name} = "{name}:get_module_config"
+
+[tool.hatch.build.targets.wheel]
+packages = ["{name}"]
 """
 
 

--- a/tests/scitex_app/appmaker/test__scaffold.py
+++ b/tests/scitex_app/appmaker/test__scaffold.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+# Timestamp: 2026-06-14
+# File: tests/scitex_app/appmaker/test__scaffold.py
+
+"""Tests for scitex_app/appmaker/_scaffold.py — nested-layout + pip-install gate.
+
+Mirrors scitex-hub PR #293 (M4 done-gate). Without these checks the scaffold
+silently emits a FLAT layout that hatchling refuses to package — every
+`pip install --target=<dir> <gitea-archive-url>` call from the hub then
+errors with "Unable to determine which files to ship inside the wheel".
+
+No mocks: the pip-install test actually builds + installs the emitted
+scaffold into a throwaway venv and imports the package back out.
+
+STX-TQ002 (AAA markers) + STX-TQ007 (one assert per test) compliant.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+import pytest
+from scitex_app.appmaker._scaffold import _pyproject_toml, init_app
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+SCAFFOLD_NAME = "demo_nested_app"
+
+
+@pytest.fixture(scope="module")
+def scaffolded_wrapper(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Scaffold once per test module — every layout test reads this tree."""
+    wrapper = tmp_path_factory.mktemp("wrapper") / "wrapper_root"
+    init_app(target_dir=wrapper, name=SCAFFOLD_NAME, label="Demo Nested")
+    return wrapper
+
+
+@pytest.fixture(scope="module")
+def emitted_pyproject() -> str:
+    """Render the pyproject template once per test module."""
+    return _pyproject_toml("demo_app", "Demo", "test desc", "AGPL-3.0")
+
+
+# ---------------------------------------------------------------------------
+# Layout — wrapper-root files (one assert each)
+# ---------------------------------------------------------------------------
+
+
+WRAPPER_ROOT_FILES = (
+    "pyproject.toml",
+    "README.md",
+    "LICENSE",
+    "AGENTS.md",
+    ".gitignore",
+)
+
+
+@pytest.mark.parametrize("relpath", WRAPPER_ROOT_FILES)
+def test_wrapper_root_file_exists(scaffolded_wrapper: Path, relpath: str) -> None:
+    # Arrange
+    candidate = scaffolded_wrapper / relpath
+    # Act
+    exists = candidate.is_file()
+    # Assert
+    assert exists
+
+
+# ---------------------------------------------------------------------------
+# Layout — nested-package files (one assert each)
+# ---------------------------------------------------------------------------
+
+
+NESTED_PACKAGE_FILES = (
+    "__init__.py",
+    "apps.py",
+    "views.py",
+    "urls.py",
+    "tests.py",
+    "skill.py",
+    "_cli.py",
+    "manifest.json",
+)
+
+
+@pytest.mark.parametrize("relpath", NESTED_PACKAGE_FILES)
+def test_nested_package_file_exists(scaffolded_wrapper: Path, relpath: str) -> None:
+    # Arrange
+    candidate = scaffolded_wrapper / SCAFFOLD_NAME / relpath
+    # Act
+    exists = candidate.is_file()
+    # Assert
+    assert exists
+
+
+# ---------------------------------------------------------------------------
+# Layout — nested templates / static / .agents / docs (one assert each)
+# ---------------------------------------------------------------------------
+
+
+def test_nested_template_index_html_exists(scaffolded_wrapper: Path) -> None:
+    # Arrange
+    candidate = (
+        scaffolded_wrapper / SCAFFOLD_NAME / "templates" / SCAFFOLD_NAME / "index.html"
+    )
+    # Act
+    exists = candidate.is_file()
+    # Assert
+    assert exists
+
+
+def test_nested_template_index_partial_html_exists(
+    scaffolded_wrapper: Path,
+) -> None:
+    # Arrange
+    candidate = (
+        scaffolded_wrapper
+        / SCAFFOLD_NAME
+        / "templates"
+        / SCAFFOLD_NAME
+        / "index_partial.html"
+    )
+    # Act
+    exists = candidate.is_file()
+    # Assert
+    assert exists
+
+
+def test_nested_static_css_exists(scaffolded_wrapper: Path) -> None:
+    # Arrange
+    candidate = (
+        scaffolded_wrapper
+        / SCAFFOLD_NAME
+        / "static"
+        / SCAFFOLD_NAME
+        / "css"
+        / f"{SCAFFOLD_NAME}.css"
+    )
+    # Act
+    exists = candidate.is_file()
+    # Assert
+    assert exists
+
+
+def test_nested_agents_json_exists(scaffolded_wrapper: Path) -> None:
+    # Arrange
+    candidate = scaffolded_wrapper / SCAFFOLD_NAME / ".agents" / "agents.json"
+    # Act
+    exists = candidate.is_file()
+    # Assert
+    assert exists
+
+
+def test_nested_platform_docs_exists(scaffolded_wrapper: Path) -> None:
+    # Arrange
+    candidate = scaffolded_wrapper / SCAFFOLD_NAME / "docs" / "PLATFORM.md"
+    # Act
+    exists = candidate.is_file()
+    # Assert
+    assert exists
+
+
+# ---------------------------------------------------------------------------
+# Flat-layout regression guards (one assert each)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flat_relpath",
+    [
+        "apps.py",
+        "views.py",
+        "urls.py",
+        "__init__.py",
+        "tests.py",
+        "skill.py",
+        "_cli.py",
+        "manifest.json",
+        "templates",
+        "static",
+        ".agents",
+        "docs",
+    ],
+)
+def test_flat_layout_path_does_not_exist(
+    scaffolded_wrapper: Path, flat_relpath: str
+) -> None:
+    """Wrapper-root must NOT contain the python-package files — that
+    would be the FLAT-layout regression the #293 fix targets."""
+    # Arrange
+    candidate = scaffolded_wrapper / flat_relpath
+    # Act
+    exists = candidate.exists()
+    # Assert
+    assert not exists
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml — hatchling wheel-packages block (one assert each)
+# ---------------------------------------------------------------------------
+
+
+def test_pyproject_has_hatchling_wheel_targets_section(
+    emitted_pyproject: str,
+) -> None:
+    """Without this section hatchling can't detect the nested package
+    directory and the wheel build fails with 'Unable to determine which
+    files to ship inside the wheel'."""
+    # Arrange
+    needle = "[tool.hatch.build.targets.wheel]"
+    # Act
+    has_section = needle in emitted_pyproject
+    # Assert
+    assert has_section
+
+
+def test_pyproject_declares_packages_list() -> None:
+    """The packages list must reference the python module name (with
+    underscores) — the package directory hatchling will ship."""
+    # Arrange
+    pyproject = _pyproject_toml("demo_app", "Demo", "test desc", "AGPL-3.0")
+    # Act
+    has_packages_decl = 'packages = ["demo_app"]' in pyproject
+    # Assert
+    assert has_packages_decl
+
+
+# ---------------------------------------------------------------------------
+# Manifest in nested location (one assert each)
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_lands_inside_nested_package_dir(
+    scaffolded_wrapper: Path,
+) -> None:
+    """manifest.json must be inside <name>/ so hatchling ships it with
+    the wheel — and the runtime registry can find it at install-target."""
+    # Arrange
+    candidate = scaffolded_wrapper / SCAFFOLD_NAME / "manifest.json"
+    # Act
+    exists = candidate.is_file()
+    # Assert
+    assert exists
+
+
+def test_manifest_name_field_matches_module(scaffolded_wrapper: Path) -> None:
+    # Arrange
+    manifest_path = scaffolded_wrapper / SCAFFOLD_NAME / "manifest.json"
+    # Act
+    data = json.loads(manifest_path.read_text())
+    # Assert
+    assert data["name"] == SCAFFOLD_NAME
+
+
+# ---------------------------------------------------------------------------
+# Real pip-install gate (no mocks)
+# ---------------------------------------------------------------------------
+
+
+def _venv_bin(venv_dir: Path) -> Path:
+    return venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+
+
+@pytest.fixture(scope="module")
+def installed_app(tmp_path_factory: pytest.TempPathFactory) -> dict:
+    """Scaffold → fresh venv → pip install → record outcomes for assertion.
+
+    Shared across the two pip-install gate tests so the (slow) install
+    only happens once per module. Returns the CompletedProcess for the
+    install + the import-check CompletedProcess.
+    """
+    name = "demo_install_app"
+    wrapper_root = tmp_path_factory.mktemp("install") / "wrapper"
+    init_app(target_dir=wrapper_root, name=name, label="Demo Install")
+
+    venv_dir = tmp_path_factory.mktemp("install") / "v"
+    builder = venv.EnvBuilder(with_pip=True, clear=True)
+    builder.create(str(venv_dir))
+
+    pip = _venv_bin(venv_dir) / "pip"
+    install_proc = subprocess.run(
+        [
+            str(pip),
+            "install",
+            "--no-deps",
+            str(wrapper_root),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    py = _venv_bin(venv_dir) / "python"
+    import_proc = subprocess.run(
+        [str(py), "-c", f"import {name}; print({name}.__file__)"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    return {
+        "name": name,
+        "install": install_proc,
+        "import_check": import_proc,
+    }
+
+
+@pytest.mark.slow
+def test_pip_install_returncode_zero(installed_app: dict) -> None:
+    """The flat-layout regression manifests as hatchling refusing to
+    build the wheel — pip install then exits non-zero."""
+    # Arrange
+    install = installed_app["install"]
+    # Act
+    rc = install.returncode
+    # Assert
+    assert rc == 0, (
+        f"pip install failed:\nstdout:\n{install.stdout}\nstderr:\n{install.stderr}"
+    )
+
+
+@pytest.mark.slow
+def test_installed_package_importable(installed_app: dict) -> None:
+    """After install, the python module must be importable from the
+    installed venv — the contract `pip install --target=<dir> <pkg>`
+    relies on (the hub's pip_install_user_app workflow)."""
+    # Arrange
+    import_check = installed_app["import_check"]
+    # Act
+    rc = import_check.returncode
+    # Assert
+    assert rc == 0, f"post-install import failed:\nstderr:\n{import_check.stderr}"


### PR DESCRIPTION
## Summary

Port of scitex-cloud PR #293 (M4 done-gate) into the canonical scitex-app generator. The hub's `pip_install_user_app` calls `pip install --no-deps --target=<dir> <gitea-archive-url>` against the scaffold's output. Pre-fix, the generator emitted a FLAT layout (everything next to `pyproject.toml`) and hatchling refused to package it:

```
ERROR: Unable to determine which files to ship inside the wheel using the following heuristics ...
```

So every user-app install failed at build time.

## Fix

1. **Nest the Python-package files under `<name>/`**:

   ```
   <wrapper>/
   ├── pyproject.toml       ← wrapper root: metadata read directly
   ├── README.md
   ├── LICENSE
   ├── AGENTS.md
   ├── .gitignore
   └── <name>/              ← nested: hatchling auto-detects the package dir
       ├── __init__.py
       ├── apps.py
       ├── views.py
       ├── urls.py
       ├── tests.py
       ├── skill.py
       ├── _cli.py          ← moved from root (was breaking [project.scripts] <slug> = "<name>._cli:main")
       ├── manifest.json
       ├── templates/<name>/{index,index_partial}.html
       ├── static/<name>/css/<name>.css
       ├── .agents/agents.json
       └── docs/PLATFORM.md
   ```

2. **Emit `[tool.hatch.build.targets.wheel] packages = ["<name>"]`** in the generated `pyproject.toml` so hatchling picks up the nested package.

## Tests

`tests/scitex_app/appmaker/test__scaffold.py` — 36 cases, STX-TQ002/TQ007 compliant, **no mocks**:

- Wrapper-root + nested-package file existence (parametrized)
- FLAT-layout regression guards: 12 paths must NOT exist at wrapper root
- pyproject contains `[tool.hatch.build.targets.wheel]` + `packages = ["<name>"]`
- manifest.json lands inside nested dir + name field matches module
- **REAL pip-install gate** (`@pytest.mark.slow`): scaffold → fresh `python -m venv` → `pip install <wrapper>` → import the package back. Without the nested layout + the hatch wheel block, this fails with hatchling's "Unable to determine which files to ship" error.

Local run: **36 passed in 17.6s** on Python 3.12.

Also registered the `slow` pytest marker in `pyproject.toml` to silence the unknown-marker warning.

## Downstream

scitex-hub's local appmaker fallback (`_scaffold.py`, PR #293) becomes redundant once this merges + a scitex-app release ships + scitex-hub bumps its `scitex-app>=<new>` pin. The hub side will then revert the fallback (the canonical CLI path will work directly).

## Test plan

- [ ] CI matrix (3.11/3.12/3.13) — verify the new pip-install gate runs cleanly across versions
- [ ] After merge → release → bump `scitex-hub` pin → verify `scitex-hub app init` (canonical CLI path, not local fallback) emits nested layout
- [ ] Revert scitex-hub's local fallback workaround

## Refs

- scitex-cloud PR #293 (M4 done-gate, `def8e7abd` on develop)
- Lead msg `06b488e1` — cross-repo write-gate granted by hub lead