### PR TITLE
chore(release): bump to 0.2.9 — appmaker nested-package layout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-06-14
+
+- fix(appmaker): emit nested-package layout (`<wrapper>/<name>/`) + add
+  `[tool.hatch.build.targets.wheel] packages = ["<name>"]` block to
+  generated `pyproject.toml`. Pre-fix the scaffold emitted a FLAT layout
+  that hatchling refused to package — every `pip install --no-deps
+  --target=<dir> <gitea-archive-url>` from the hub then failed with
+  "Unable to determine which files to ship inside the wheel". Port of
+  scitex-cloud PR #293 M4 done-gate. New test gate
+  (`tests/scitex_app/appmaker/test__scaffold.py`, 36 cases, no mocks,
+  incl. real `pip install` into a fresh venv) prevents regression. (#35)
+
 ## [0.2.8] - 2026-05-26
 
 - test: de-mock + fix test quality; fix fastmcp call-tool API drift

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-app"
-version = "0.2.8"
+version = "0.2.9"
 description = "SciTeX App SDK — write-once interface for local + cloud apps"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Release for PR #35 (`fix(appmaker): emit nested-package layout + add hatchling wheel block`).

After this PR merges to develop, tag `v0.2.9` will be pushed → `pypi-publish-and-github-release-on-tag.yml` runs the release pipeline (matrix pytest → build wheel/sdist → PyPI OIDC publish → GitHub Release from CHANGELOG → develop→main sync PR).

scitex-hub will then bump its `scitex-app>=0.2.9` pin; the canonical `scitex-hub app init` CLI path emits the correct nested layout, and the local fallback workaround can be reverted.

## Summary
- pyproject.toml: 0.2.8 → 0.2.9
- CHANGELOG.md: new 0.2.9 section pointing at #35

## Test plan
- [ ] CI matrix green
- [ ] After merge: `git tag v0.2.9 && git push origin v0.2.9` (hub agent)
- [ ] Watch release workflow → PyPI publish
- [ ] scitex-hub: bump pin → verify → revert local fallback