### PR TITLE
chore(release): bump to 0.2.10 (skip orphan 0.2.9 tag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.2.9] - 2026-06-14
+## [0.2.10] - 2026-06-14
+
+(Version 0.2.9 was claimed by an earlier orphan tag on 2026-06-03 that
+never published to PyPI; jumping to 0.2.10 to avoid the conflict.)
 
 - fix(appmaker): emit nested-package layout (`<wrapper>/<name>/`) + add
   `[tool.hatch.build.targets.wheel] packages = ["<name>"]` block to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-app"
-version = "0.2.9"
+version = "0.2.10"
 description = "SciTeX App SDK — write-once interface for local + cloud apps"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
The v0.2.9 git tag was created on 2026-06-03 for an earlier PR (#30 + #22) but never published to PyPI. Rather than do a destructive remote-tag delete, we jump to 0.2.10 — the orphan stays as cosmetic debt; PyPI sees a clean 0.2.8 → 0.2.10 progression.

Same payload as the (now-superseded) 0.2.9 release-PR #36: ships the appmaker nested-package layout fix from #35 (M4 generator done-gate).

## Summary
- pyproject.toml: 0.2.9 → 0.2.10
- CHANGELOG.md: rename 0.2.9 section → 0.2.10 with the orphan-tag note

## Test plan
- [ ] CI matrix green
- [ ] Admin-merge
- [ ] Tag v0.2.10 + push → release workflow runs → PyPI publish
- [ ] Bump scitex-hub `scitex-app>=0.2.10` → verify `scitex-hub app init` (canonical CLI path) emits nested layout → revert local fallback

## Refs
- Supersedes #36 (which was for the conflicting 0.2.9 bump)
- Builds on #35 (the actual appmaker fix)
- Lead msg `d795a490` — picked (a) bump path, do NOT delete orphan v0.2.9 tag